### PR TITLE
Add an opam file 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.vo
+*.glob
+*.aux
+.coqdeps.d
+Makefile.coq
+Makefile.coq.conf

--- a/opam
+++ b/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+name: "coq-poltac"
+description: "Tactics for polynomial manipulations"
+maintainer: "Laurent.Thery@sophia.inria.fr"
+authors: [
+  "Laurent Thery <laurent.thery@sophia.inria.fr>"
+]
+homepage: "https://github.com/thery/PolTac"
+bug-reports: "https://github.com/thery/PolTac/issues"
+dev-repo: "https://github.com/thery/PolTac.git"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  [make "uninstall"]
+]
+depends: [
+  "coq" {>= "8.5"}
+]


### PR DESCRIPTION
I find it convenient to have an `opam` file in the repository, because it allows me to install the library using `opam pin` (full command would be `opam pin coq-poltac.dev https://github.com/thery/PolTac`).
It could also be reused as-is if at some point you want to submit an opam package for PolTac.