### PR TITLE
Fix Indentation

### DIFF
--- a/NAux.v
+++ b/NAux.v
@@ -4,7 +4,8 @@ Require Import ZArith.
 
 Open Scope N_scope.
 
-Theorem Nle_le: forall n  m, (N.to_nat n <= N.to_nat m)%nat -> n <= m.
+Theorem Nle_le: forall n m, (N.to_nat n <= N.to_nat m)%nat -> n <= m.
+Proof.
 intros n m; case n; case m; unfold N.le; simpl; try (intros; discriminate).
 intros p; elim p using Pind; simpl.
 intros H1; inversion H1.
@@ -15,19 +16,22 @@ apply nat_of_P_gt_Gt_compare_morphism; auto.
 Qed.
 
 Theorem le_Nle: forall n m, N.of_nat n <= N.of_nat m -> (n <= m)%nat.
+Proof.
 intros n m; case n; case m; unfold N.le; simpl; auto with arith.
 intros n1 H1; case H1; auto.
 intros m1 n1 H1; case (le_or_lt n1 m1); auto with arith.
 intros H2; case H1.
 apply nat_of_P_gt_Gt_compare_complement_morphism.
-repeat rewrite  nat_of_P_o_P_of_succ_nat_eq_succ; auto with arith.
+repeat rewrite nat_of_P_o_P_of_succ_nat_eq_succ; auto with arith.
 Qed.
 
-Theorem Nle_le_rev: forall n  m, n <= m -> (N.to_nat n <= N.to_nat m)%nat.
+Theorem Nle_le_rev: forall n m, n <= m -> (N.to_nat n <= N.to_nat m)%nat.
+Proof.
 intros; apply le_Nle; repeat rewrite N2Nat.id; auto.
 Qed.
 
-Theorem Nlt_lt: forall n  m, (N.to_nat n < N.to_nat m)%nat -> n < m.
+Theorem Nlt_lt: forall n m, (N.to_nat n < N.to_nat m)%nat -> n < m.
+Proof.
 intros n m; case n; case m; unfold N.lt; simpl; try (intros; discriminate); auto.
 intros H1; inversion H1.
 intros p H1; inversion H1.
@@ -35,18 +39,21 @@ intros; apply nat_of_P_lt_Lt_compare_complement_morphism; auto.
 Qed.
 
 Theorem lt_Nlt: forall n m, N.of_nat n < N.of_nat m -> (n < m)%nat.
+Proof.
 intros n m; case n; case m; unfold N.lt; simpl; try (intros; discriminate); auto with arith.
 intros m1 n1 H1.
 rewrite <- (Nat2N.id (S n1)); rewrite <- (Nat2N.id (S m1)).
 simpl; apply nat_of_P_lt_Lt_compare_morphism; auto.
 Qed.
 
-Theorem Nlt_lt_rev: forall n  m, n < m -> (N.to_nat n < N.to_nat m)%nat.
+Theorem Nlt_lt_rev: forall n m, n < m -> (N.to_nat n < N.to_nat m)%nat.
+Proof.
 intros; apply lt_Nlt; repeat rewrite N2Nat.id; auto.
 Qed.
 
 
-Theorem Nge_ge: forall n  m, (N.to_nat n >= N.to_nat m)%nat -> n >= m.
+Theorem Nge_ge: forall n m, (N.to_nat n >= N.to_nat m)%nat -> n >= m.
+Proof.
 intros n m; case n; case m; unfold N.ge; simpl; try (intros; discriminate); auto.
 intros p; elim p using Pind; simpl.
 intros H1; inversion H1.
@@ -57,21 +64,23 @@ apply nat_of_P_lt_Lt_compare_morphism; auto.
 Qed.
 
 Theorem ge_Nge: forall n m, N.of_nat n >= N.of_nat m -> (n >= m)%nat.
+Proof.
 intros n m; case n; case m; unfold N.ge; simpl; try (intros; discriminate); auto with arith.
 intros n1 H1; case H1; auto.
 intros m1 n1 H1.
 case (le_or_lt m1 n1); auto with arith.
 intros H2; case H1.
 apply nat_of_P_lt_Lt_compare_complement_morphism.
-repeat rewrite  nat_of_P_o_P_of_succ_nat_eq_succ; auto with arith.
+repeat rewrite nat_of_P_o_P_of_succ_nat_eq_succ; auto with arith.
 Qed.
 
-Theorem Nge_ge_rev: forall n  m, n >= m -> (N.to_nat n >= N.to_nat m)%nat.
+Theorem Nge_ge_rev: forall n m, n >= m -> (N.to_nat n >= N.to_nat m)%nat.
+Proof.
 intros; apply ge_Nge; repeat rewrite N2Nat.id; auto.
 Qed.
 
-
-Theorem Ngt_gt: forall n  m, (N.to_nat n > N.to_nat m)%nat -> n > m.
+Theorem Ngt_gt: forall n m, (N.to_nat n > N.to_nat m)%nat -> n > m.
+Proof.
 intros n m; case n; case m; unfold N.gt; simpl; try (intros; discriminate); auto.
 intros H1; inversion H1.
 intros p H1; inversion H1.
@@ -79,107 +88,128 @@ intros; apply nat_of_P_gt_Gt_compare_complement_morphism; auto.
 Qed.
 
 Theorem gt_Ngt: forall n m, N.of_nat n > N.of_nat m -> (n > m)%nat.
+Proof.
 intros n m; case n; case m; unfold N.gt; simpl; try (intros; discriminate); auto with arith.
 intros m1 n1 H1.
 rewrite <- (Nat2N.id (S n1)); rewrite <- (Nat2N.id (S m1)).
 simpl; apply nat_of_P_gt_Gt_compare_morphism; auto.
 Qed.
 
-Theorem Ngt_gt_rev: forall n  m, n > m -> (N.to_nat n > N.to_nat m)%nat.
+Theorem Ngt_gt_rev: forall n m, n > m -> (N.to_nat n > N.to_nat m)%nat.
+Proof.
 intros; apply gt_Ngt; repeat rewrite N2Nat.id; auto.
 Qed.
 
-Theorem Neq_eq_rev: forall n  m, n = m -> (N.to_nat n = N.to_nat m)%nat.
+Theorem Neq_eq_rev: forall n m, n = m -> (N.to_nat n = N.to_nat m)%nat.
+Proof.
 intros n m H; rewrite H; auto.
 Qed.
 
 Theorem Nmult_lt_compat_l: forall n m p, n < m -> 0 < p -> p * n < p * m.
+Proof.
 intros n m p H1 H2; apply Nlt_lt; repeat rewrite N2Nat.inj_mul.
 apply mult_lt_compat_l; apply lt_Nlt; repeat rewrite N2Nat.id; auto.
 Qed.
 
 Theorem Nmult_le_compat_l: forall n m p, n <= m -> p * n <= p * m.
+Proof.
 intros n m p H1; apply Nle_le; repeat rewrite N2Nat.inj_mul.
 apply Mult.mult_le_compat_l; apply le_Nle; repeat rewrite N2Nat.id; auto.
 Qed.
 
 Theorem Nmult_ge_compat_l: forall n m p, n >= m -> p * n >= p * m.
+Proof.
 intros n m p H1; apply Nge_ge; repeat rewrite N2Nat.inj_mul.
 apply mult_ge_compat_l; apply ge_Nge; repeat rewrite N2Nat.id; auto.
 Qed.
 
 Theorem Nmult_gt_compat_l: forall n m p, n > m -> p > 0 -> p * n > p * m.
+Proof.
 intros n m p H1 H2; apply Ngt_gt; repeat rewrite N2Nat.inj_mul.
 apply mult_gt_compat_l; apply gt_Ngt; repeat rewrite N2Nat.id; auto.
 Qed.
 
 Theorem Nmult_lt_compat_rev_l1: forall n m p, p * n < p * m -> 0 < p.
+Proof.
 intros n m p H1; apply Nlt_lt; apply mult_lt_compat_rev_l1 with (nat_of_N n) (nat_of_N m).
 repeat rewrite <- N2Nat.inj_mul; apply lt_Nlt; repeat rewrite N2Nat.id; auto.
 Qed.
 
 Theorem Nmult_lt_compat_rev_l2: forall n m p, p * n < p * m -> n < m.
+Proof.
 intros n m p H1; apply Nlt_lt; apply mult_lt_compat_rev_l2 with (nat_of_N p).
 repeat rewrite <- N2Nat.inj_mul; apply lt_Nlt; repeat rewrite N2Nat.id; auto.
 Qed.
 
 Theorem Nmult_gt_compat_rev_l1: forall n m p, p * n > p * m -> p > 0.
+Proof.
 intros n m p H1; apply Ngt_gt; apply mult_gt_compat_rev_l1 with (nat_of_N n) (nat_of_N m).
 repeat rewrite <- N2Nat.inj_mul; apply gt_Ngt; repeat rewrite N2Nat.id; auto.
 Qed.
 
 Theorem Nmult_gt_compat_rev_l2: forall n m p, p * n > p * m -> n > m.
+Proof.
 intros n m p H1; apply Ngt_gt; apply mult_gt_compat_rev_l2 with (nat_of_N p).
 repeat rewrite <- N2Nat.inj_mul; apply gt_Ngt; repeat rewrite N2Nat.id; auto.
 Qed.
 
 Theorem Nmult_le_compat_rev_l: forall n m p, p * n <= p * m -> 0 < p -> n <= m.
+Proof.
 intros n m p H1 H2; apply Nle_le; apply mult_le_compat_rev_l with (nat_of_N p).
 repeat rewrite <- N2Nat.inj_mul; apply le_Nle; repeat rewrite N2Nat.id; auto.
 apply lt_Nlt; repeat rewrite N2Nat.id; auto.
 Qed.
 
 Theorem Nmult_ge_compat_rev_l: forall n m p , p * n >= p * m -> 0 < p -> n >= m.
+Proof.
 intros n m p H1 H2; apply Nge_ge; apply mult_ge_compat_rev_l with (nat_of_N p).
 repeat rewrite <- N2Nat.inj_mul; apply ge_Nge; repeat rewrite N2Nat.id; auto.
 apply lt_Nlt; repeat rewrite N2Nat.id; auto.
 Qed.
 
 Theorem Nlt_mult_0: forall a b, 0 < a -> 0 < b -> 0 < a * b.
+Proof.
 intros a b H1 H2; apply Nlt_lt; rewrite N2Nat.inj_mul; apply lt_mult_0; apply lt_Nlt; repeat rewrite N2Nat.id; auto.
 Qed.
 
 Theorem Ngt_mult_0: forall a b, a > 0 -> b > 0 -> a * b > 0.
+Proof.
 intros a b H1 H2; apply Ngt_gt; rewrite N2Nat.inj_mul; apply gt_mult_0; apply gt_Ngt; repeat rewrite N2Nat.id; auto.
 Qed.
 
-Theorem Nlt_mult_rev_0_l: forall a b, 0 < a * b ->  0 < a .
+Theorem Nlt_mult_rev_0_l: forall a b, 0 < a * b -> 0 < a .
+Proof.
 intros a b H1; apply Nlt_lt; apply lt_mult_rev_0_l with (nat_of_N b).
 rewrite <- N2Nat.inj_mul; apply lt_Nlt; repeat rewrite N2Nat.id; auto.
 Qed.
 
-Theorem Nlt_mult_rev_0_r: forall a b, 0 < a * b ->  0 < b .
+Theorem Nlt_mult_rev_0_r: forall a b, 0 < a * b -> 0 < b .
+Proof.
 intros a b H1; apply Nlt_lt; apply lt_mult_rev_0_r with (nat_of_N a).
 rewrite <- N2Nat.inj_mul; apply lt_Nlt; repeat rewrite N2Nat.id; auto.
 Qed.
 
-Theorem Ngt_mult_rev_0_l: forall a b, a * b > 0 ->  a > 0.
+Theorem Ngt_mult_rev_0_l: forall a b, a * b > 0 -> a > 0.
+Proof.
 intros a b H1; apply Ngt_gt; apply gt_mult_rev_0_l with (nat_of_N b).
 rewrite <- N2Nat.inj_mul; apply gt_Ngt; repeat rewrite N2Nat.id; auto.
 Qed.
 
-Theorem Ngt_mult_rev_0_r: forall a b, a * b > 0  ->  b > 0 .
+Theorem Ngt_mult_rev_0_r: forall a b, a * b > 0 -> b > 0 .
+Proof.
 intros a b H1; apply Ngt_gt; apply gt_mult_rev_0_r with (nat_of_N a).
 rewrite <- N2Nat.inj_mul; apply gt_Ngt; repeat rewrite N2Nat.id; auto.
 Qed.
 
 Theorem Nle_0_eq_0: forall n, n <= 0 -> n = 0.
+Proof.
 intros n H1; rewrite <- (N2Nat.id n).
 rewrite (le_0_eq_0 (nat_of_N n)); auto.
 apply le_Nle; rewrite N2Nat.id; auto.
 Qed.
 
 Theorem Nge_0_eq_0: forall n, 0 >= n -> n = 0.
+Proof.
 intros n H1; rewrite <- (N2Nat.id n).
 rewrite (le_0_eq_0 (nat_of_N n)); auto.
 change (0 >= nat_of_N n)%nat.
@@ -188,44 +218,45 @@ Qed.
 
 Import BinPos.
 
-
-Ltac to_nat_op  :=
+Ltac to_nat_op :=
   match goal with
-      H: (N.lt _ _) |- _ => generalize (Nlt_lt_rev _ _ H); clear H; intros H
-|     H: (N.gt _ _) |- _ => generalize (Ngt_gt_rev _ _ H); clear H; intros H
-|     H: (N.le _ _) |- _ => generalize (Nle_le_rev _ _ H); clear H; intros H
-|     H: (N.ge _ _) |- _ => generalize (Nge_ge_rev _ _ H); clear H; intros H
-|     H: (@eq N _ _) |- _ => generalize (Neq_eq_rev _ _ H); clear H; intros H
-|      |- (N.lt _ _)  => apply Nlt_lt
-|      |- (N.le _ _)  => apply Nle_le
-|      |- (N.gt _ _)  => apply Ngt_gt
-|      |- (N.ge _ _)  => apply Nge_ge
-|      |- (@eq N _ _)  => apply Nat2N.inj
-end.
+  | H: (N.lt _ _) |- _ => generalize (Nlt_lt_rev _ _ H); clear H; intros H
+  | H: (N.gt _ _) |- _ => generalize (Ngt_gt_rev _ _ H); clear H; intros H
+  | H: (N.le _ _) |- _ => generalize (Nle_le_rev _ _ H); clear H; intros H
+  | H: (N.ge _ _) |- _ => generalize (Nge_ge_rev _ _ H); clear H; intros H
+  | H: (@eq N _ _) |- _ => generalize (Neq_eq_rev _ _ H); clear H; intros H
+  | |- (N.lt _ _) => apply Nlt_lt
+  | |- (N.le _ _) => apply Nle_le
+  | |- (N.gt _ _) => apply Ngt_gt
+  | |- (N.ge _ _) => apply Nge_ge
+  | |- (@eq N _ _) => apply Nat2N.inj
+  end.
 
 Ltac set_to_nat :=
-let nn := fresh "nn" in
-match goal with
-       |- context [(N.to_nat (?X + ?Y)%N)]  => rewrite N2Nat.inj_add
-|      |- context [(N.to_nat (?X * ?Y)%N)]  => rewrite N2Nat.inj_mul
-|      |- context [(N.to_nat ?X)]  => set (nn:=N.to_nat X) in * |- *
-|      H: context [(N.to_nat (?X + ?Y)%N)] |- _ => rewrite N2Nat.inj_add in H
-|      H: context [(N.to_nat (?X + ?Y)%N)] |- _ => rewrite N2Nat.inj_mul in H
-|      H: context [(N.to_nat ?X)] |- _ => set (nn:=N.to_nat X) in * |- *
-end.
+  let nn := fresh "nn" in
+  match goal with
+  | |- context [(N.to_nat (?X + ?Y)%N)] => rewrite N2Nat.inj_add
+  | |- context [(N.to_nat (?X * ?Y)%N)] => rewrite N2Nat.inj_mul
+  | |- context [(N.to_nat ?X)] => set (nn:=N.to_nat X) in * |- *
+  | H: context [(N.to_nat (?X + ?Y)%N)] |- _ => rewrite N2Nat.inj_add in H
+  | H: context [(N.to_nat (?X + ?Y)%N)] |- _ => rewrite N2Nat.inj_mul in H
+  | H: context [(N.to_nat ?X)] |- _ => set (nn:=N.to_nat X) in * |- *
+  end.
 
 Ltac to_nat := repeat to_nat_op; repeat set_to_nat.
 
 Theorem Nle_gt_trans: forall n m p, m <= n -> m > p -> n > p.
+Proof.
 intros; to_nat; apply le_gt_trans with nn1; auto.
 Qed.
 
 Theorem Ngt_le_trans: forall n m p, n > m -> p <= m -> n > p.
+Proof.
 intros; to_nat; apply gt_le_trans with nn1; auto.
 Qed.
 
-Theorem Nle_add_l :
-  forall x y, x <= y + x.
+Theorem Nle_add_l : forall x y, x <= y + x.
+Proof.
 intros; to_nat; auto with arith.
 Qed.
 

--- a/NGroundTac.v
+++ b/NGroundTac.v
@@ -1,19 +1,14 @@
-Require Import NAux.
-
+Require Import NArith.
 
 Open Scope N_scope.
 
 Theorem Lt_diff_Gt: Lt <> Gt.
-intros; discriminate.
-Qed.
+Proof. discriminate. Qed.
 
 Theorem Eq_diff_Gt: Eq <> Gt.
-intros; discriminate.
-Qed.
+Proof. discriminate. Qed.
 
 Close Scope N_scope.
 
 Hint Extern 4 (N.lt ?X1 ?X2) => exact (refl_equal Lt).
 Hint Extern 4 (N.le ?X1 ?X2) => exact Lt_diff_Gt || exact Eq_diff_Gt.
-
-

--- a/NPolF.v
+++ b/NPolF.v
@@ -1,4 +1,3 @@
-Require Import ZArith.
 Require Import NAux.
 Require Import NPolS.
 Require Import PolSBase.
@@ -8,69 +7,66 @@ Require Import PolAuxList.
 Require Import NSignTac.
 
 
-Definition Zfactor := 
+Definition Zfactor :=
   factor Z Zplus Zmult Z.opp 0%Z 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div Zgcd.
 
-Definition Zfactor_minus := 
+Definition Zfactor_minus :=
   factor_sub Z Zplus Zmult Z.opp 0%Z 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div Zgcd.
 
+Definition Zget_delta :=
+  get_delta Z Zplus Zmult Z.opp 0%Z 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div Zgcd.
 
-Definition Zget_delta := 
- get_delta Z Zplus Zmult Z.opp 0%Z 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div Zgcd.
 
-
-Ltac
-Nfactor_term term1 term2 :=
-let term := constr:(Nminus term1 term2) in
-let rfv := FV NCst Nplus Nmult Nminus Nopp term (@nil N) in
-let fv := Trev rfv in
-let expr1 := mkPolexpr Z NCst Nplus Nmult Nminus Nopp term1 fv in
-let expr2 := mkPolexpr Z NCst Nplus Nmult Nminus Nopp term2 fv in
-let re := eval vm_compute in (Zfactor_minus (PEsub expr1 expr2)) in
-let factor := match re with (PEmul ?X1 _) => X1 end in
-let expr3 := match re with (PEmul _ (PEsub ?X1 _)) => X1 end in
-let expr4 := match re with (PEmul _ (PEsub _ ?X1 )) => X1 end in
-let
- re1' :=
-  eval
-     unfold
-      Nconvert_back, convert_back,  pos_nth,  jump, 
-         hd,  tl in (Nconvert_back (PEmul factor expr3) fv) in
-let re1'' := eval lazy beta in re1' in
-let re1''' := clean_zabs_N re1'' in
-let
- re2' :=
-  eval
-     unfold
-      Nconvert_back, convert_back,  pos_nth,  jump, 
-         hd,  tl in (Nconvert_back (PEmul factor expr4) fv) in
-let re2'' := eval lazy beta in re2' in 
-let re2''' := clean_zabs_N re2'' in
-replace2_tac term1 term2 re1''' re2'''; [idtac| ring | ring].
-
+Ltac Nfactor_term term1 term2 :=
+  let term := constr:(Nminus term1 term2) in
+  let rfv := FV NCst Nplus Nmult Nminus Nopp term (@nil N) in
+  let fv := Trev rfv in
+  let expr1 := mkPolexpr Z NCst Nplus Nmult Nminus Nopp term1 fv in
+  let expr2 := mkPolexpr Z NCst Nplus Nmult Nminus Nopp term2 fv in
+  let re := (eval vm_compute in (Zfactor_minus (PEsub expr1 expr2))) in
+  let factor := match re with (PEmul ?X1 _) => X1 end in
+  let expr3 := match re with (PEmul _ (PEsub ?X1 _)) => X1 end in
+  let expr4 := match re with (PEmul _ (PEsub _ ?X1 )) => X1 end in
+  let re1' :=
+      (eval
+         unfold
+         Nconvert_back, convert_back, pos_nth, jump,
+       hd, tl in (Nconvert_back (PEmul factor expr3) fv))
+  in
+  let re1'' := (eval lazy beta in re1') in
+  let re1''' := clean_zabs_N re1'' in
+  let re2' :=
+      (eval
+         unfold
+         Nconvert_back, convert_back, pos_nth, jump,
+       hd, tl in (Nconvert_back (PEmul factor expr4) fv))
+  in
+  let re2'' := (eval lazy beta in re2') in
+  let re2''' := clean_zabs_N re2'' in
+  replace2_tac term1 term2 re1''' re2'''; [idtac | ring | ring].
 
 Ltac Npolf :=
-progress (
-(try 
-match goal with
-| |- (?X1 = ?X2)%N =>  Nfactor_term X1 X2 
-| |- (?X1 <> ?X2)%N =>  Nfactor_term X1 X2 
-| |- N.lt ?X1 ?X2 => Nfactor_term X1 X2
-| |- N.gt ?X1 ?X2 =>Nfactor_term X1 X2
-| |- N.le ?X1 ?X2 => Nfactor_term X1 X2
-| |- N.ge ?X1 ?X2 =>Nfactor_term X1 X2
-| _ => fail end)); try (Nsign_tac); try repeat (rewrite Nmult_1_l || rewrite Nmult_1_r).
+  progress
+    (try match goal with
+         | |- (?X1 = ?X2)%N => Nfactor_term X1 X2
+         | |- (?X1 <> ?X2)%N => Nfactor_term X1 X2
+         | |- N.lt ?X1 ?X2 => Nfactor_term X1 X2
+         | |- N.gt ?X1 ?X2 => Nfactor_term X1 X2
+         | |- N.le ?X1 ?X2 => Nfactor_term X1 X2
+         | |- N.ge ?X1 ?X2 => Nfactor_term X1 X2
+         | _ => fail end);
+  try Nsign_tac; try repeat (rewrite Nmult_1_l || rewrite Nmult_1_r).
 
-
-Ltac hyp_Npolf H := 
-progress (
-generalize H; 
-(try 
-match type of H with
-  (?X1 = ?X2)%N =>  Nfactor_term X1 X2 
-| (?X1 <> ?X2)%N =>  Nfactor_term X1 X2 
-| N.lt ?X1 ?X2 => Nfactor_term X1 X2
-| N.gt ?X1 ?X2 =>Nfactor_term X1 X2
-| N.le ?X1 ?X2 => Nfactor_term X1 X2 
-| N.ge ?X1 ?X2 =>Nfactor_term X1 X2
-| _ => fail end)); clear H; intros H; try hyp_Nsign_tac H; try repeat rewrite Nmult_1_l in H.
+Ltac hyp_Npolf H :=
+  progress
+    (generalize H;
+     try match type of H with
+         | (?X1 = ?X2)%N => Nfactor_term X1 X2
+         | (?X1 <> ?X2)%N => Nfactor_term X1 X2
+         | N.lt ?X1 ?X2 => Nfactor_term X1 X2
+         | N.gt ?X1 ?X2 => Nfactor_term X1 X2
+         | N.le ?X1 ?X2 => Nfactor_term X1 X2
+         | N.ge ?X1 ?X2 => Nfactor_term X1 X2
+         | _ => fail end);
+  clear H; intros H;
+  try hyp_Nsign_tac H; try repeat rewrite Nmult_1_l in H.

--- a/NPolR.v
+++ b/NPolR.v
@@ -6,151 +6,160 @@ Require Import PolAuxList.
 Require Import NPolS.
 Require Import NPolF.
 Require Import PolRBase.
- 
+
+
 Definition Nreplace_term_aux :=
   replace Z Zplus Zmult Z.opp 0%Z 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div.
 
-Ltac
-Nreplace_term term from to occ id :=
-let rfv := FV NCst Nplus Nmult Nminus Nopp term (@nil N) in
-let rfv1 := FV NCst Nplus Nmult Nminus Nopp from rfv in
-let rfv2 := FV NCst Nplus Nmult Nminus Nopp to rfv1 in
-let fv := Trev rfv2 in
-let expr := mkPolexpr Z NCst Nplus Nmult Nminus Nopp term fv in
-let expr_from := mkPolexpr Z NCst Nplus Nmult Nminus Nopp from fv in
-let expr_to := mkPolexpr Z NCst Nplus Nmult Nminus Nopp to fv in
-let re := eval vm_compute in (Nreplace_term_aux expr expr_from expr_to occ) in
-let term1 := eval
-     unfold Nconvert_back, convert_back,  pos_nth,  jump,
-         hd,  tl in (Nconvert_back re fv) in
-let term2 := clean_zabs_N term1 in
-match id with 
-     true => term2
+
+Ltac Nreplace_term term from to occ id :=
+  let rfv := FV NCst Nplus Nmult Nminus Nopp term (@nil N) in
+  let rfv1 := FV NCst Nplus Nmult Nminus Nopp from rfv in
+  let rfv2 := FV NCst Nplus Nmult Nminus Nopp to rfv1 in
+  let fv := Trev rfv2 in
+  let expr := mkPolexpr Z NCst Nplus Nmult Nminus Nopp term fv in
+  let expr_from := mkPolexpr Z NCst Nplus Nmult Nminus Nopp from fv in
+  let expr_to := mkPolexpr Z NCst Nplus Nmult Nminus Nopp to fv in
+  let re := (eval vm_compute in (Nreplace_term_aux expr expr_from expr_to occ)) in
+  let term1 :=
+      (eval
+         unfold
+         Nconvert_back, convert_back, pos_nth, jump,
+       hd, tl in (Nconvert_back re fv))
+  in
+  let term2 := clean_zabs_N term1 in
+  match id with
+  | true => term2
   | false =>
-     match eqterm term term1 with
-       |false => term2
+    match eqterm term term1 with
+    | false => term2
     end
-end
-.
+  end .
 
 Ltac Npol_is_compare term :=
-match term with
-| (_ < _)%N => constr:(true)
-| (_ > _)%N => constr:(true)
-| (_ <= _)%N => constr:(true)
-| (_ >= _)%N => constr:(true)
-| (?X = _)%N => match type of X with N => constr:(true) end
-| _ => constr:(false)
-end.
-
-Ltac Npol_get_term dir term :=
-match term with
-|  (?op ?X  ?Y)%N =>
-     match dir with P.L => X | P.R => Y end
-|  (?X = ?Y)%N =>
-     match dir with P.L => X | P.R => Y end
-| _ => fail 1 "Unknown term in Npol_get_term"
-end.
-
-Ltac Npol_replace_term term1 term2 dir1 dir2 occ id := 
-  let dir2opp := eval compute in (P.pol_dir_opp dir2) in
-  let t1 := Npol_get_term dir2 term2 in
-  let t2 := match id with true => t1 | false =>  Npol_get_term dir2opp term2 end in
- match term1 with
-   | (?op ?X ?Y) =>
-     match dir1 with
-       P.L  =>
-             Nreplace_term X t1 t2 occ id
-       | P.R => 
-            Nreplace_term Y t1 t2 occ id
-      end
-  | (?X = ?Y)%N  =>
-     match dir1 with
-       P.L  =>
-             Nreplace_term X t1 t2 occ id
-     | P.R => 
-             Nreplace_term Y  t1 t2 occ id
-      end
+  match term with
+  | (_ < _)%N => constr:(true)
+  | (_ > _)%N => constr:(true)
+  | (_ <= _)%N => constr:(true)
+  | (_ >= _)%N => constr:(true)
+  | (?X = _)%N => match type of X with N => constr:(true) end
+  | _ => constr:(false)
   end.
 
+Ltac Npol_get_term dir term :=
+  match term with
+  | (?op ?X ?Y)%N => match dir with P.L => X | P.R => Y end
+  | (?X = ?Y)%N => match dir with P.L => X | P.R => Y end
+  | _ => fail 1 "Unknown term in Npol_get_term"
+  end.
+
+Ltac Npol_replace_term term1 term2 dir1 dir2 occ id :=
+  let dir2opp := (eval compute in (P.pol_dir_opp dir2)) in
+  let t1 := Npol_get_term dir2 term2 in
+  let t2 :=
+      match id with
+      | true => t1
+      | false => Npol_get_term dir2opp term2
+      end
+  in
+  match term1 with
+  | (?op ?X ?Y) =>
+    match dir1 with
+    | P.L => Nreplace_term X t1 t2 occ id
+    | P.R => Nreplace_term Y t1 t2 occ id
+    end
+  | (?X = ?Y)%N =>
+    match dir1 with
+    | P.L => Nreplace_term X t1 t2 occ id
+    | P.R => Nreplace_term Y t1 t2 occ id
+    end
+  end.
 
 Ltac Npol_aux_dir term dir :=
   match term with
-   (_ < _)%N => dir
+  | (_ < _)%N => dir
   | (_ > _)%N => dir
-  | (_ <= _)%N => eval compute in (P.pol_dir_opp dir) 
-  | (_ >= _)%N => eval compute in (P.pol_dir_opp dir) 
-end.
+  | (_ <= _)%N => eval compute in (P.pol_dir_opp dir)
+  | (_ >= _)%N => eval compute in (P.pol_dir_opp dir)
+  end.
 
 (* Do the replacement *)
 Ltac Nreplace_tac_full term dir1 dir2 occ :=
-match term with
- (?T1 = ?T2)%N =>
-  (* We have here a substitution *)
-  match goal with
-     |-  ?G => let  t := Npol_replace_term G term dir1 dir2 occ false in
-              match dir1 with
-               P.L =>
-                      apply trans_equal with t ||
-                      apply Neq_lt_trans_l with t || apply Neq_gt_trans_l with t ||
-                       apply Neq_le_trans_l with t || apply Neq_ge_trans_l with t
-              | P.R =>
-                     apply trans_equal_r with t ||
-                       apply Neq_lt_trans_r with t || apply Neq_gt_trans_r with t ||
-                       apply Neq_le_trans_r with t || apply Neq_ge_trans_r with t
-              end
-  end
-| _ =>
-   match goal with
-     |- (?X <= ?Y)%N  =>
-            let  t := Npol_replace_term (X <= Y)%N term dir1 dir2 occ false in
-               apply N.le_trans with t
-     |  |- (?X >= ?Y)%N =>
-            let  t := Npol_replace_term (X >= Y)%N term dir1 dir2 occ false in
-               apply Nge_trans with t
-     | |- ?G  =>
-            let  t := Npol_replace_term G term dir1 dir2 occ false in
-           match Npol_aux_dir term dir1 with
-                P.L =>
-                                    (apply N.lt_le_trans with t || apply Ngt_le_trans with t)
-               |P.R =>
-                                    (apply N.le_lt_trans with t || apply Nle_gt_trans with t)
-            end
-   end
-end.
+  match term with
+  | (?T1 = ?T2)%N =>
+    (* We have here a substitution *)
+    match goal with
+    | |- ?G =>
+      let t := Npol_replace_term G term dir1 dir2 occ false in
+      match dir1 with
+      | P.L =>
+        (apply trans_equal with t)
+        || (apply Neq_lt_trans_l with t)
+        || (apply Neq_gt_trans_l with t)
+        || (apply Neq_le_trans_l with t)
+        || (apply Neq_ge_trans_l with t)
+      | P.R =>
+        (apply trans_equal_r with t)
+        || (apply Neq_lt_trans_r with t)
+        || (apply Neq_gt_trans_r with t)
+        || (apply Neq_le_trans_r with t)
+        || (apply Neq_ge_trans_r with t)
+      end
+    end
+  | _ =>
+    match goal with
+    | |- (?X <= ?Y)%N =>
+      let t := Npol_replace_term (X <= Y)%N term dir1 dir2 occ false in
+      apply N.le_trans with t
+    | |- (?X >= ?Y)%N =>
+      let t := Npol_replace_term (X >= Y)%N term dir1 dir2 occ false in
+      apply Nge_trans with t
+    | |- ?G =>
+      let t := Npol_replace_term G term dir1 dir2 occ false in
+      match Npol_aux_dir term dir1 with
+      | P.L => apply N.lt_le_trans with t || apply Ngt_le_trans with t
+      | P.R => apply N.le_lt_trans with t || apply Nle_gt_trans with t
+      end
+    end
+  end.
 
 (* Make the term appears *)
 Ltac Nreplace_tac_full_id term dir1 dir2 occ :=
   match goal with
-     |-  ?G => let t1 := Npol_replace_term G term dir1 dir2 occ true in 
-                match dir1 with
-                  P.L =>
-                       apply trans_equal with t1 ||
-                       apply Neq_lt_trans_l with t1 ||
-                       apply Neq_gt_trans_l with t1 ||
-                       apply Neq_le_trans_l with t1 ||
-                       apply Neq_ge_trans_l with t1
-               | P.R =>
-                      apply trans_equal_r with t1 ||
-                      apply Neq_lt_trans_r with t1 ||
-                      apply Neq_gt_trans_r with t1  ||
-                      apply Neq_le_trans_r with t1 ||
-                      apply Neq_ge_trans_r with t1
-                end; [ring | idtac]
-end.
+  | |- ?G =>
+    let t1 := Npol_replace_term G term dir1 dir2 occ true in
+    match dir1 with
+    | P.L =>
+      (apply trans_equal with t1)
+      || (apply Neq_lt_trans_l with t1)
+      || (apply Neq_gt_trans_l with t1)
+      || (apply Neq_le_trans_l with t1)
+      || (apply Neq_ge_trans_l with t1)
+    | P.R =>
+      (apply trans_equal_r with t1)
+      || (apply Neq_lt_trans_r with t1)
+      || (apply Neq_gt_trans_r with t1)
+      || (apply Neq_le_trans_r with t1)
+      || (apply Neq_ge_trans_r with t1)
+    end; [ring | idtac]
+  end.
 
 Ltac Npolrx term dir1 dir2 occ :=
-match Npol_is_compare term with
-  true => Nreplace_tac_full_id term dir1 dir2 occ; [Nreplace_tac_full term dir1 dir2 occ] 
-| false => 
-     let t := type of term in
-     match Npol_is_compare t with true => 
-        Nreplace_tac_full_id t dir1 dir2 occ; [Nreplace_tac_full t dir1 dir2 occ]
-     end 
-end.
+  match Npol_is_compare term with
+  | true =>
+    Nreplace_tac_full_id term dir1 dir2 occ;
+    [Nreplace_tac_full term dir1 dir2 occ]
+  | false =>
+    let t := type of term in
+    match Npol_is_compare t with
+    | true =>
+      Nreplace_tac_full_id t dir1 dir2 occ;
+      [Nreplace_tac_full t dir1 dir2 occ]
+    end
+  end.
 
 Ltac Npolr term :=
-  Npolrx term P.L P.L 1%Z  ||
-  Npolrx term P.R P.L 1%Z ||
-  Npolrx term P.L P.R 1%Z ||
-  Npolrx term P.R P.R 1%Z.
+  Npolrx term P.L P.L 1%Z
+  || Npolrx term P.R P.L 1%Z
+  || Npolrx term P.L P.R 1%Z
+  || Npolrx term P.R P.R 1%Z.

--- a/NPolS.v
+++ b/NPolS.v
@@ -1,88 +1,73 @@
 Require Import PolSBase.
 Require Import PolAuxList.
 Require Import PolAux.
-Require Import NAux.
-Require Export ArithRing.
 
-Open Scope nat_scope.
 
 Definition Nconvert_back (e : PExpr Z) (l : list N) : N :=
-   convert_back Z N 0%N Nplus Nminus Nmult Nopp Z.abs_N l e.
- 
+  convert_back Z N 0%N Nplus Nminus Nmult Nopp Z.abs_N l e.
+
 Definition Nsimpl_minus (e : PExpr Z) :=
-   simpl_minus
+  simpl_minus
     Z Zplus Zmult Z.opp Z0 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div e.
- 
+
 Definition Nsimpl (e : PExpr Z) :=
-   simpl
+  simpl
     Z Zplus Zmult Z.opp Z0 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div e.
 
+Ltac Ns term1 term2 :=
+  let term := constr:(Nminus term1 term2) in
+  let rfv := FV NCst Nplus Nmult Nminus Nopp term (@nil N) in
+  let fv := Trev rfv in
+  let expr1 := mkPolexpr Z NCst Nplus Nmult Nminus Nopp term1 fv in
+  let expr2 := mkPolexpr Z NCst Nplus Nmult Nminus Nopp term2 fv in
+  let re := (eval vm_compute in (Nsimpl_minus (PEsub expr1 expr2))) in
+  let expr3 := match re with (PEsub ?X1 _) => X1 end in
+  let expr4 := match re with (PEsub _ ?X1) => X1 end in
+  let re1 := (eval vm_compute in (Nsimpl (PEsub expr1 expr3))) in
+  let re1' :=
+      (eval
+         unfold
+         Nconvert_back, convert_back, PolAuxList.pos_nth, PolAuxList.jump,
+       PolAuxList.hd, PolAuxList.tl in (Nconvert_back (PEadd re1 expr3) fv))
+  in
+  let re1'' := (eval lazy beta in re1') in
+  let re1''' := clean_zabs_N re1'' in
+  let re2' :=
+      (eval
+         unfold
+         Nconvert_back, convert_back, PolAuxList.pos_nth, PolAuxList.jump,
+       PolAuxList.hd, PolAuxList.tl in (Nconvert_back (PEadd re1 expr4) fv))
+  in
+  let re2'' := (eval lazy beta in re2') in
+  let re2''' := clean_zabs_N re2'' in
+  replace2_tac term1 term2 re1''' re2'''; [idtac | ring | ring].
 
-Ltac
-Ns term1 term2 :=
-let term := constr:(Nminus term1 term2) in
-let rfv := FV NCst Nplus Nmult Nminus Nopp term (@nil N) in
-let fv := Trev rfv in
-let expr1 := mkPolexpr Z NCst Nplus Nmult Nminus Nopp term1 fv in
-let expr2 := mkPolexpr Z NCst Nplus Nmult Nminus Nopp term2 fv in
-let re := eval vm_compute in (Nsimpl_minus (PEsub expr1 expr2)) in
-let expr3 := match re with (PEsub ?X1 _) => X1 end in
-let expr4 := match re with (PEsub _ ?X1 ) => X1 end in
-let re1 := eval vm_compute in (Nsimpl (PEsub expr1 expr3)) in
-let
- re1' :=
-  eval
-     unfold
-      Nconvert_back, convert_back,  PolAuxList.pos_nth,  PolAuxList.jump, 
-         PolAuxList.hd,  PolAuxList.tl in (Nconvert_back (PEadd re1 expr3) fv) in
-let re1'' := eval lazy beta in re1' in
-let re1''' := clean_zabs_N re1'' in
-let
- re2' :=
-  eval
-     unfold
-      Nconvert_back, convert_back,  PolAuxList.pos_nth,  PolAuxList.jump, 
-         PolAuxList.hd,  PolAuxList.tl in (Nconvert_back (PEadd re1 expr4) fv) in
-let re2'' := eval lazy beta in re2' in
-let re2''' := clean_zabs_N re2'' in
-replace2_tac term1 term2 re1''' re2'''; [idtac | ring | ring].
-(*
-(replace term with re2; [idtac | try ring]).
-*)
+Ltac Npols :=
+  match goal with
+  | |- (?X1 = ?X2)%N => Ns X1 X2; apply Nplus_eq_compat_l
+  | |- (?X1 <> ?X2)%N => Ns X1 X2; apply Nplus_neg_compat_l
+  | |- (?X1 < ?X2)%N => Ns X1 X2; apply Nplus_lt_compat_l
+  | |- (?X1 > ?X2)%N => Ns X1 X2; apply Nplus_gt_compat_l
+  | |- (?X1 <= ?X2)%N => Ns X1 X2; apply Nplus_le_compat_l
+  | |- (?X1 >= ?X2)%N => Ns X1 X2; apply Nplus_ge_compat_l
+  | _ => fail
+  end.
 
-Ltac
-Npols :=
-match goal with
-| |- (?X1 = ?X2)%N =>
-Ns X1 X2; apply Nplus_eq_compat_l
-| |- (?X1 <> ?X2)%N =>
-Ns X1 X2; apply Nplus_neg_compat_l
-| |- (?X1 < ?X2)%N =>
-Ns X1 X2; apply Nplus_lt_compat_l
-| |- (?X1 > ?X2)%N =>
-Ns X1 X2; apply Nplus_gt_compat_l
-| |- (?X1 <= ?X2)%N =>
-Ns X1 X2; apply Nplus_le_compat_l
-| |- (?X1 >= ?X2)%N =>
-Ns X1 X2; apply Nplus_ge_compat_l
-| _ => fail end.
-
-
-Ltac
-hyp_Npols H :=
-generalize H;
-let tmp := fresh "tmp" in
-match (type of H) with
-   (?X1 = ?X2)%N =>
-Ns X1 X2; intros tmp; generalize (Nplus_reg_l _ _ _ tmp); clear H tmp; intro H
-|  (?X1 <> ?X2)%N =>
-Ns X1 X2; intros tmp; generalize (Nplus_neg_reg_l _ _ _ tmp); clear H tmp; intro H
-|  (?X1 < ?X2)%N =>
-Ns X1 X2; intros tmp; generalize (Nplus_lt_reg_l _ _ _ tmp); clear H tmp; intro H
-|  (?X1 > ?X2)%N =>
-Ns X1 X2; intros tmp; generalize (Nplus_gt_reg_l _ _ _ tmp); clear H tmp; intro H
-|  (?X1 <= ?X2)%N =>
-Ns X1 X2; intros tmp; generalize (Nplus_le_reg_l _ _ _ tmp); clear H tmp; intro H
-|  (?X1 >= ?X2)%N =>
-Ns X1 X2; intros tmp; generalize (Nplus_ge_reg_l _ _ _ tmp); clear H tmp; intro H
-| _ => fail end.
+Ltac hyp_Npols H :=
+  generalize H;
+  let tmp := fresh "tmp" in
+  match (type of H) with
+    (?X1 = ?X2)%N =>
+    Ns X1 X2; intros tmp; generalize (Nplus_reg_l _ _ _ tmp); clear H tmp; intro H
+  | (?X1 <> ?X2)%N =>
+    Ns X1 X2; intros tmp; generalize (Nplus_neg_reg_l _ _ _ tmp); clear H tmp; intro H
+  | (?X1 < ?X2)%N =>
+    Ns X1 X2; intros tmp; generalize (Nplus_lt_reg_l _ _ _ tmp); clear H tmp; intro H
+  | (?X1 > ?X2)%N =>
+    Ns X1 X2; intros tmp; generalize (Nplus_gt_reg_l _ _ _ tmp); clear H tmp; intro H
+  | (?X1 <= ?X2)%N =>
+    Ns X1 X2; intros tmp; generalize (Nplus_le_reg_l _ _ _ tmp); clear H tmp; intro H
+  | (?X1 >= ?X2)%N =>
+    Ns X1 X2; intros tmp; generalize (Nplus_ge_reg_l _ _ _ tmp); clear H tmp; intro H
+  | _ => fail
+  end.

--- a/NSignTac.v
+++ b/NSignTac.v
@@ -7,50 +7,53 @@ Open Scope N_scope.
 
 
 Ltac Nsign_tac :=
- repeat (apply Nmult_le_compat_l || apply Nmult_lt_compat_l ||
-              apply Nmult_ge_compat_l || apply Nmult_gt_compat_l ||
-              apply Nlt_mult_0 || apply Ngt_mult_0); auto.
+  repeat (apply Nmult_le_compat_l || apply Nmult_lt_compat_l ||
+          apply Nmult_ge_compat_l || apply Nmult_gt_compat_l ||
+          apply Nlt_mult_0 || apply Ngt_mult_0); auto.
 
 Ltac hyp_Nsign_tac H :=
   match type of H with
-   0 <= _ => clear H
-| (?X1 <= 0)%N => generalize (Nle_0_eq_0 _ H); clear H; intros H; subst X1
-|  (?X1 * _ <= ?X1 * _)%N =>
-             let s1 := fresh "NS" in
-                   (assert (s1: 0 < X1); [Nsign_tac; fail |
-                   generalize (Nmult_le_compat_rev_l _ _ _ H s1);
-                   clear H s1; intros H])
-|   (0  < ?X1 * _)%N  =>
-              let s1 := fresh "NS" in
-                   (generalize (Nlt_mult_rev_0_l _ _ H);
-                    generalize (Nlt_mult_rev_0_r _ _ H); clear H;
-                    intros H s1; hyp_Nsign_tac s1; hyp_Nsign_tac H)
-|  (?X1 < 0)%N => absurd (~ (X1 < 0)%N); auto
-| (?X1 * _  < ?X1 * _)%N =>
-              let s1 := fresh "NS" in
-                   (generalize (Nmult_lt_compat_rev_l1 _ _ _ H);
-                    generalize (Nmult_lt_compat_rev_l2 _ _ _ H); clear H;
-                    intros H s1; hyp_Nsign_tac s1; hyp_Nsign_tac H)
-|  (?X1 >= 0)%N => clear H
-| (0 >= ?X1)%N  => generalize (Nge_0_eq_0 _ H); clear H; intros H; subst X1
-|  (?X1 * _ >= ?X1 * _)%N =>
-             let s1 := fresh "NS" in
-                   (assert (s1: (0 < X1)%N); [Nsign_tac; fail |
-                   generalize (Nmult_ge_compat_rev_l _ _ _ H s1);
-                   clear H s1; intros H])
-|  (?X1 * _ > 0 )%N =>
-              let s1 := fresh "NS" in
-                   (generalize (Ngt_mult_rev_0_l _ _ H);
-                    generalize (Ngt_mult_rev_0_r _ _ H); clear H;
-                    intros H s1; hyp_Nsign_tac s1; hyp_Nsign_tac H)
-|  (0 > ?X1)%N => absurd (~ (0 > X1)%N); auto with arith
-| (?X1 * _  > ?X1 * _)%N =>
-              let s1 := fresh "NS" in
-                   (generalize (Nmult_gt_compat_rev_l1 _ _ _ H);
-                    generalize (Nmult_gt_compat_rev_l2 _ _ _ H); clear H;
-                    intros H s1; hyp_Nsign_tac s1; hyp_Nsign_tac H)
-  |  _ => (let u := type of H in (clear H; assert (H: u); [auto; fail | clear H]) || idtac)
-
-   end.
+  | 0 <= _ => clear H
+  | (?X1 <= 0)%N => generalize (Nle_0_eq_0 _ H); clear H; intros H; subst X1
+  | (?X1 * _ <= ?X1 * _)%N =>
+    let s1 := fresh "NS" in
+    assert (s1: 0 < X1);
+    [ Nsign_tac; fail
+    | generalize (Nmult_le_compat_rev_l _ _ _ H s1);
+      clear H s1; intros H ]
+  | (0 < ?X1 * _)%N =>
+    let s1 := fresh "NS" in
+    generalize (Nlt_mult_rev_0_l _ _ H);
+    generalize (Nlt_mult_rev_0_r _ _ H); clear H;
+    intros H s1; hyp_Nsign_tac s1; hyp_Nsign_tac H
+  | (?X1 < 0)%N => absurd (~ (X1 < 0)%N); auto
+  | (?X1 * _ < ?X1 * _)%N =>
+    let s1 := fresh "NS" in
+    generalize (Nmult_lt_compat_rev_l1 _ _ _ H);
+    generalize (Nmult_lt_compat_rev_l2 _ _ _ H); clear H;
+    intros H s1; hyp_Nsign_tac s1; hyp_Nsign_tac H
+  | (?X1 >= 0)%N => clear H
+  | (0 >= ?X1)%N => generalize (Nge_0_eq_0 _ H); clear H; intros H; subst X1
+  | (?X1 * _ >= ?X1 * _)%N =>
+    let s1 := fresh "NS" in
+    assert (s1: (0 < X1)%N);
+    [ Nsign_tac; fail
+    | generalize (Nmult_ge_compat_rev_l _ _ _ H s1);
+      clear H s1; intros H ]
+  | (?X1 * _ > 0 )%N =>
+    let s1 := fresh "NS" in
+    generalize (Ngt_mult_rev_0_l _ _ H);
+    generalize (Ngt_mult_rev_0_r _ _ H); clear H;
+    intros H s1; hyp_Nsign_tac s1; hyp_Nsign_tac H
+  | (0 > ?X1)%N => absurd (~ (0 > X1)%N); auto with arith
+  | (?X1 * _ > ?X1 * _)%N =>
+    let s1 := fresh "NS" in
+    generalize (Nmult_gt_compat_rev_l1 _ _ _ H);
+    generalize (Nmult_gt_compat_rev_l2 _ _ _ H); clear H;
+    intros H s1; hyp_Nsign_tac s1; hyp_Nsign_tac H
+  | _ =>
+    let u := type of H in
+    (clear H; assert (H : u); [auto; fail | clear H]) || idtac
+  end.
 
 Close Scope N_scope.

--- a/NatAux.v
+++ b/NatAux.v
@@ -1,75 +1,89 @@
 Require Export Arith.
 
 Theorem mult_lt_compat_l: forall n m p : nat, n < m -> 0 < p -> p * n < p * m.
+Proof.
 intros n m p H H1; repeat rewrite (mult_comm p); apply mult_lt_compat_r; auto.
 Qed.
 
 Theorem mult_ge_compat_l: forall n m p : nat, n >= m -> p * n >= p * m.
+Proof.
 intros n m p H; auto with arith.
 Qed.
 
 Theorem mult_gt_compat_l: forall n m p : nat, n > m -> p > 0 -> p * n > p * m.
+Proof.
 intros n m p H H1; red; apply mult_lt_compat_l; auto.
 Qed.
 
 Theorem mult_lt_compat_rev_l1: forall n m p : nat, p * n < p * m -> 0 < p.
+Proof.
 intros n m p; case p; auto with arith.
 Qed.
 
 Theorem mult_lt_compat_rev_l2: forall n m p : nat, p * n < p * m -> n < m.
+Proof.
 intros n m p H; case (le_or_lt m n); auto with arith; intros H1.
 absurd (p * n < p * m); auto with arith.
 apply le_not_lt; apply mult_le_compat_l; auto.
 Qed.
 
-
 Theorem mult_gt_compat_rev_l1: forall n m p : nat, p * n > p * m -> p > 0.
+Proof.
 intros n m p; case p; auto with arith.
 Qed.
 
 Theorem mult_gt_compat_rev_l2: forall n m p : nat, p * n > p * m -> n > m.
+Proof.
 intros n m p H; case (le_or_lt n m); auto with arith; intros H1.
 absurd (p * n > p * m); auto with arith.
 Qed.
 
 Theorem mult_le_compat_rev_l: forall n m p : nat, p * n <= p * m -> 0 < p -> n <= m.
+Proof.
 intros n m p H H1; case (le_or_lt n m); auto with arith; intros H2; absurd (p * n <= p * m); auto with arith.
 apply lt_not_le; apply mult_lt_compat_l; auto.
 Qed.
 
 Theorem mult_ge_compat_rev_l: forall n m p : nat, p * n >= p * m -> 0 < p -> n >= m.
+Proof.
 intros n m p H H1; case (le_or_lt m n); auto with arith; intros H2; absurd (p * n >= p * m); auto with arith.
 unfold ge; apply lt_not_le; apply mult_lt_compat_l; auto.
 Qed.
 
 Theorem lt_mult_0: forall a b, 0 < a -> 0 < b -> 0 < a * b.
+Proof.
 intros a b; case a ; case b; simpl; auto with arith.
 intros n H1 H2; absurd (0 < 0); auto with arith.
 Qed.
 
 Theorem gt_mult_0: forall a b, a > 0 -> b > 0 -> a * b > 0.
-intros a b H1 H2; red; apply  lt_mult_0; auto with arith.
+Proof.
+intros a b H1 H2; red; apply lt_mult_0; auto with arith.
 Qed.
 
-
-Theorem lt_mult_rev_0_l: forall a b, 0 < a * b ->  0 < a .
+Theorem lt_mult_rev_0_l: forall a b, 0 < a * b -> 0 < a .
+Proof.
 intros a b; case a; simpl; auto with arith.
 Qed.
 
-Theorem lt_mult_rev_0_r: forall a b, 0 < a * b ->  0 < b .
+Theorem lt_mult_rev_0_r: forall a b, 0 < a * b -> 0 < b .
+Proof.
 intros a b; case b; simpl; auto with arith.
 rewrite mult_0_r; auto with arith.
 Qed.
 
-Theorem gt_mult_rev_0_l: forall a b, a * b > 0 ->  a > 0.
+Theorem gt_mult_rev_0_l: forall a b, a * b > 0 -> a > 0.
+Proof.
 intros a b; case a; simpl; auto with arith.
 Qed.
 
-Theorem gt_mult_rev_0_r: forall a b, a * b > 0  ->  b > 0 .
+Theorem gt_mult_rev_0_r: forall a b, a * b > 0 -> b > 0 .
+Proof.
 intros a b; case b; simpl; auto with arith.
 rewrite mult_0_r; auto with arith.
 Qed.
 
 Theorem le_0_eq_0: forall n, n <= 0 -> n = 0.
+Proof.
 intros n; case n; auto with arith.
 Qed.

--- a/NatGroundTac.v
+++ b/NatGroundTac.v
@@ -2,25 +2,23 @@ Require Import Arith.
 
 Fixpoint le_bool (n m: nat) {struct n}: bool :=
   match n, m with
-  O, _ => true
-| S n1, S m1 => le_bool n1 m1
-| _, _ => false
-end.
+  | O, _ => true
+  | S n1, S m1 => le_bool n1 m1
+  | _, _ => false
+  end.
 
 Theorem le_correct: forall n m, le_bool n m = true -> n <= m.
-induction n; destruct m; simpl; auto with arith; intros; discriminate.
-Qed.
+Proof. now induction n; destruct m; auto with arith. Qed.
 
 Fixpoint lt_bool (n m: nat) {struct n}: bool :=
   match n, m with
-  O, (S _)  => true
-| S n1, S m1 => lt_bool n1 m1
-| _, _ => false
-end.
+  | O, S _ => true
+  | S n1, S m1 => lt_bool n1 m1
+  | _, _ => false
+  end.
 
 Theorem lt_correct: forall n m, lt_bool n m = true -> n <= m.
-induction n; destruct m; simpl; auto with arith; intros; discriminate.
-Qed.
+Proof. now induction n; destruct m; auto with arith. Qed.
 
 Hint Extern 4 (?X1 <= ?X2)%nat => exact (le_correct X1 X2 (refl_equal true)).
 Hint Extern 4 (?X1 < ?X2)%nat => exact (lt_correct X1 X2 (refl_equal true)).

--- a/NatPolF.v
+++ b/NatPolF.v
@@ -7,68 +7,66 @@ Require Import PolAuxList.
 Require Import NatSignTac.
 
 
-Definition Zfactor := 
+Definition Zfactor :=
   factor Z Zplus Zmult Z.opp 0%Z 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div Zgcd.
 
-Definition Zfactor_minus := 
+Definition Zfactor_minus :=
   factor_sub Z Zplus Zmult Z.opp 0%Z 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div Zgcd.
 
+Definition Zget_delta :=
+  get_delta Z Zplus Zmult Z.opp 0%Z 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div Zgcd.
 
-Definition Zget_delta := 
- get_delta Z Zplus Zmult Z.opp 0%Z 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div Zgcd.
 
-
-Ltac
-Natfactor_term term1 term2 :=
-let term := constr:(minus term1 term2) in
-let rfv := FV NatCst plus mult minus Natopp term (@nil nat) in
-let fv := Trev rfv in
-let expr1 := mkPolexpr Z NatCst plus mult minus Natopp term1 fv in
-let expr2 := mkPolexpr Z NatCst plus mult minus Natopp term2 fv in
-let re := eval vm_compute in (Zfactor_minus (PEsub expr1 expr2)) in
-let factor := match re with (PEmul ?X1 _) => X1 end in
-let expr3 := match re with (PEmul _ (PEsub ?X1 _)) => X1 end in
-let expr4 := match re with (PEmul _ (PEsub _ ?X1 )) => X1 end in
-let
- re1' :=
-  eval
-     unfold
-      Natconvert_back, convert_back,  pos_nth,  jump, 
-         hd,  tl in (Natconvert_back (PEmul factor expr3) fv) in
-let re1'' := eval lazy beta in re1' in
-let re1''' := clean_zabs re1'' in
-let
- re2' :=
-  eval
-     unfold
-      Natconvert_back, convert_back,  pos_nth,  jump, 
-         hd,  tl in (Natconvert_back (PEmul factor expr4) fv) in
-let re2'' := eval lazy beta in re2' in 
-let re2''' := clean_zabs re2'' in
-replace2_tac term1 term2 re1''' re2'''; [idtac| ring | ring].
+Ltac Natfactor_term term1 term2 :=
+  let term := constr:(minus term1 term2) in
+  let rfv := FV NatCst plus mult minus Natopp term (@nil nat) in
+  let fv := Trev rfv in
+  let expr1 := mkPolexpr Z NatCst plus mult minus Natopp term1 fv in
+  let expr2 := mkPolexpr Z NatCst plus mult minus Natopp term2 fv in
+  let re := (eval vm_compute in (Zfactor_minus (PEsub expr1 expr2))) in
+  let factor := match re with (PEmul ?X1 _) => X1 end in
+  let expr3 := match re with (PEmul _ (PEsub ?X1 _)) => X1 end in
+  let expr4 := match re with (PEmul _ (PEsub _ ?X1 )) => X1 end in
+  let re1' :=
+      (eval
+         unfold
+         Natconvert_back, convert_back, pos_nth, jump,
+       hd, tl in (Natconvert_back (PEmul factor expr3) fv))
+  in
+  let re1'' := (eval lazy beta in re1') in
+  let re1''' := clean_zabs re1'' in
+  let re2' :=
+      (eval
+         unfold
+         Natconvert_back, convert_back, pos_nth, jump,
+       hd, tl in (Natconvert_back (PEmul factor expr4) fv))
+  in
+  let re2'' := (eval lazy beta in re2') in
+  let re2''' := clean_zabs re2'' in
+  replace2_tac term1 term2 re1''' re2'''; [idtac | ring | ring].
 
 Ltac npolf :=
-progress (
-(try 
-match goal with
-| |- (?X1 = ?X2)%nat =>  Natfactor_term X1 X2 
-| |- (?X1 <> ?X2)%nat =>  Natfactor_term X1 X2 
-| |- lt ?X1 ?X2 => Natfactor_term X1 X2
-| |- gt ?X1 ?X2 =>Natfactor_term X1 X2
-| |- le ?X1 ?X2 => Natfactor_term X1 X2
-| |- ge ?X1 ?X2 =>Natfactor_term X1 X2
-| _ => fail end)); try (nsign_tac); try repeat (rewrite mult_1_l || rewrite mult_1_r).
+  progress
+    (try match goal with
+         | |- (?X1 = ?X2)%nat => Natfactor_term X1 X2
+         | |- (?X1 <> ?X2)%nat => Natfactor_term X1 X2
+         | |- lt ?X1 ?X2 => Natfactor_term X1 X2
+         | |- gt ?X1 ?X2 => Natfactor_term X1 X2
+         | |- le ?X1 ?X2 => Natfactor_term X1 X2
+         | |- ge ?X1 ?X2 => Natfactor_term X1 X2
+         | _ => fail end);
+  try nsign_tac; try repeat (rewrite mult_1_l || rewrite mult_1_r).
 
-
-Ltac hyp_npolf H := 
-progress (
-generalize H; 
-(try 
-match type of H with
-  (?X1 = ?X2)%nat =>  Natfactor_term X1 X2 
-| (?X1 <> ?X2)%nat =>  Natfactor_term X1 X2 
-| lt ?X1 ?X2 => Natfactor_term X1 X2
-| gt ?X1 ?X2 =>Natfactor_term X1 X2
-| le ?X1 ?X2 => Natfactor_term X1 X2 
-| ge ?X1 ?X2 =>Natfactor_term X1 X2
-| _ => fail end)); clear H; intros H; try hyp_nsign_tac H; try repeat rewrite mult_1_l in H.
+Ltac hyp_npolf H :=
+  progress
+    (generalize H;
+     try match type of H with
+         | (?X1 = ?X2)%nat => Natfactor_term X1 X2
+         | (?X1 <> ?X2)%nat => Natfactor_term X1 X2
+         | lt ?X1 ?X2 => Natfactor_term X1 X2
+         | gt ?X1 ?X2 => Natfactor_term X1 X2
+         | le ?X1 ?X2 => Natfactor_term X1 X2
+         | ge ?X1 ?X2 => Natfactor_term X1 X2
+         | _ => fail end);
+  clear H; intros H;
+  try hyp_nsign_tac H; try repeat rewrite mult_1_l in H.

--- a/NatPolR.v
+++ b/NatPolR.v
@@ -5,162 +5,164 @@ Require Import PolAuxList.
 Require Import NatPolS.
 Require Import NatPolF.
 Require Import PolRBase.
- 
+
+
 Definition Natreplace_term_aux :=
   replace Z Zplus Zmult Z.opp 0%Z 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div.
 
-Ltac
-Natreplace_term term from to occ id :=
-let rfv := FV NatCst plus mult minus Natopp term (@nil nat) in
-let rfv1 := FV NatCst plus mult minus Natopp from rfv in
-let rfv2 := FV NatCst plus mult minus Natopp to rfv1 in
-let fv := Trev rfv2 in
-let expr := mkPolexpr Z NatCst plus mult minus Natopp term fv in
-let expr_from := mkPolexpr Z NatCst plus mult minus Natopp from fv in
-let expr_to := mkPolexpr Z NatCst plus mult minus Natopp to fv in
-let re := eval vm_compute in (Natreplace_term_aux expr expr_from expr_to occ) in
-let term1 := eval
-     unfold Natconvert_back, convert_back,  pos_nth,  jump,
-         hd,  tl in (Natconvert_back re fv) in
-let term2 := clean_zabs term1 in
-match id with 
-     true => term2
+
+Ltac Natreplace_term term from to occ id :=
+  let rfv := FV NatCst plus mult minus Natopp term (@nil nat) in
+  let rfv1 := FV NatCst plus mult minus Natopp from rfv in
+  let rfv2 := FV NatCst plus mult minus Natopp to rfv1 in
+  let fv := Trev rfv2 in
+  let expr := mkPolexpr Z NatCst plus mult minus Natopp term fv in
+  let expr_from := mkPolexpr Z NatCst plus mult minus Natopp from fv in
+  let expr_to := mkPolexpr Z NatCst plus mult minus Natopp to fv in
+  let re := (eval vm_compute in (Natreplace_term_aux expr expr_from expr_to occ)) in
+  let term1 :=
+      (eval
+         unfold Natconvert_back, convert_back, pos_nth, jump,
+       hd, tl in (Natconvert_back re fv))
+  in
+  let term2 := clean_zabs term1 in
+  match id with
+  | true => term2
   | false =>
-     match eqterm term term1 with
-       |false => term2
+    match eqterm term term1 with
+    | false => term2
     end
-end
-.
-
-Ltac npol_is_compare term :=
-match term with
-| (_ < _)%nat => constr:(true)
-| (_ > _)%nat => constr:(true)
-| (_ <= _)%nat => constr:(true)
-| (_ >= _)%nat => constr:(true)
-| (?X = _)%nat => match type of X with nat => constr:(true) end
-| _ => constr:(false)
-end.
-
-Ltac npol_get_term dir term :=
-match term with
-|  (?op ?X  ?Y)%nat =>
-     match dir with P.L => X | P.R => Y end
-|  (?X = ?Y)%nat =>
-     match dir with P.L => X | P.R => Y end
-| _ => fail 1 "Unknown term in npol_get_term"
-end.
-
-Ltac npol_replace_term term1 term2 dir1 dir2 occ id := 
-  let dir2opp := eval compute in (P.pol_dir_opp dir2) in
-  let t1 := npol_get_term dir2 term2 in
-  let t2 := match id with true => t1 | false => npol_get_term dir2opp term2 end in
-  match term1 with
-   | (?op ?X ?Y) =>
-     match dir1 with
-         P.L  =>
-             Natreplace_term X t1 t2 occ id
-       | P.R => 
-            Natreplace_term Y t1 t2 occ id
-      end
-  | (?X = ?Y)%nat  =>
-     match dir1 with
-       P.L  =>
-             Natreplace_term X t1 t2 occ id
-     | P.R => 
-             Natreplace_term Y  t1 t2 occ id
-      end
   end.
 
+Ltac npol_is_compare term :=
+  match term with
+  | (_ < _)%nat => constr:(true)
+  | (_ > _)%nat => constr:(true)
+  | (_ <= _)%nat => constr:(true)
+  | (_ >= _)%nat => constr:(true)
+  | (?X = _)%nat => match type of X with nat => constr:(true) end
+  | _ => constr:(false)
+  end.
+
+Ltac npol_get_term dir term :=
+  match term with
+  | (?op ?X ?Y)%nat => match dir with P.L => X | P.R => Y end
+  | (?X = ?Y)%nat => match dir with P.L => X | P.R => Y end
+  | _ => fail 1 "Unknown term in npol_get_term"
+  end.
+
+Ltac npol_replace_term term1 term2 dir1 dir2 occ id :=
+  let dir2opp := (eval compute in (P.pol_dir_opp dir2)) in
+  let t1 := npol_get_term dir2 term2 in
+  let t2 :=
+      match id with
+      | true => t1
+      | false => npol_get_term dir2opp term2
+      end
+  in
+  match term1 with
+  | (?op ?X ?Y) =>
+    match dir1 with
+    | P.L => Natreplace_term X t1 t2 occ id
+    | P.R => Natreplace_term Y t1 t2 occ id
+    end
+  | (?X = ?Y)%nat =>
+    match dir1 with
+    | P.L => Natreplace_term X t1 t2 occ id
+    | P.R => Natreplace_term Y t1 t2 occ id
+    end
+  end.
 
 Ltac npol_aux_dir term dir :=
   match term with
-   (_ < _)%nat => dir
+  | (_ < _)%nat => dir
   | (_ > _)%nat => dir
-  | (_ <= _)%nat => eval compute in (P.pol_dir_opp dir) 
-  | (_ >= _)%nat => eval compute in (P.pol_dir_opp dir) 
-end.
+  | (_ <= _)%nat => eval compute in (P.pol_dir_opp dir)
+  | (_ >= _)%nat => eval compute in (P.pol_dir_opp dir)
+  end.
 
-Ltac Nat_eq_trans_l t:= 
-   match goal with
-     |  |- (?X >= ?Y)%nat => apply eq_ge_trans_l with t 
-     |  |- (?X > ?Y)%nat => apply eq_gt_trans_l with t 
-     |  |- (?X <= ?Y)%nat => apply eq_le_trans_l with t 
-     |  |- (?X < ?Y)%nat => apply eq_lt_trans_l with t 
-     |  |- ?G  => apply trans_equal with t 
-    end.
+Ltac Nat_eq_trans_l t:=
+  match goal with
+  | |- (?X >= ?Y)%nat => apply eq_ge_trans_l with t
+  | |- (?X > ?Y)%nat => apply eq_gt_trans_l with t
+  | |- (?X <= ?Y)%nat => apply eq_le_trans_l with t
+  | |- (?X < ?Y)%nat => apply eq_lt_trans_l with t
+  | |- ?G => apply trans_equal with t
+  end.
 
-Ltac Nat_eq_trans_r t:= 
-   match goal with
-     |  |- (?X >= ?Y)%nat => apply eq_ge_trans_r with t 
-     |  |- (?X > ?Y)%nat => apply eq_gt_trans_r with t 
-     |  |- (?X <= ?Y)%nat => apply eq_le_trans_r with t 
-     |  |- (?X < ?Y)%nat => apply eq_lt_trans_r with t 
-     |  |- ?G  => apply trans_equal_r with t 
-    end.
+Ltac Nat_eq_trans_r t:=
+  match goal with
+  | |- (?X >= ?Y)%nat => apply eq_ge_trans_r with t
+  | |- (?X > ?Y)%nat => apply eq_gt_trans_r with t
+  | |- (?X <= ?Y)%nat => apply eq_le_trans_r with t
+  | |- (?X < ?Y)%nat => apply eq_lt_trans_r with t
+  | |- ?G => apply trans_equal_r with t
+  end.
 
 (* Do the replacement *)
 Ltac Natreplace_tac_full term dir1 dir2 occ :=
-match term with
- (?T1 = ?T2)%nat =>
-  (* We have here a substitution *)
-  match goal with
-     |-  ?G => let  t := npol_replace_term G term dir1 dir2 occ false in
-              match dir1 with
-               P.L => Nat_eq_trans_l t
-              | P.R => Nat_eq_trans_r t
-              end
-  end
-| _ =>
-   match goal with
-     |  |- (?X >= ?Y)%nat =>
-            let  t := npol_replace_term (X >= Y)%nat term dir1 dir2 occ false in
-               apply ge_trans with t
-     |  |- (?X <= ?Y)%nat =>
-            let  t := npol_replace_term (X <= Y)%nat term dir1 dir2 occ false in
-               apply le_trans with t
-     |  |- (?X > ?Y)%nat  =>
-            let  t := npol_replace_term (X > Y)%nat term dir1 dir2 occ false in
-           match npol_aux_dir term dir1 with
-                P.L =>
-                                    (apply gt_le_trans with t)
-               |P.R =>
-                                    (apply le_gt_trans with t)
-            end
-     |  |- (?X < ?Y)%nat   =>
-            let  t := npol_replace_term (X < Y)%nat term dir1 dir2 occ false in
-           match npol_aux_dir term dir1 with
-                P.L =>
-                                    (apply lt_le_trans with t)
-               |P.R =>
-                                    (apply le_lt_trans with t)
-            end
-   end
-end.
+  match term with
+  | (?T1 = ?T2)%nat =>
+    (* We have here a substitution *)
+    match goal with
+    | |- ?G =>
+      let t := npol_replace_term G term dir1 dir2 occ false in
+      match dir1 with
+      | P.L => Nat_eq_trans_l t
+      | P.R => Nat_eq_trans_r t
+      end
+    end
+  | _ =>
+    match goal with
+    | |- (?X >= ?Y)%nat =>
+      let t := npol_replace_term (X >= Y)%nat term dir1 dir2 occ false in
+      apply ge_trans with t
+    | |- (?X <= ?Y)%nat =>
+      let t := npol_replace_term (X <= Y)%nat term dir1 dir2 occ false in
+      apply le_trans with t
+    | |- (?X > ?Y)%nat =>
+      let t := npol_replace_term (X > Y)%nat term dir1 dir2 occ false in
+      match npol_aux_dir term dir1 with
+      | P.L => apply gt_le_trans with t
+      | P.R => apply le_gt_trans with t
+      end
+    | |- (?X < ?Y)%nat =>
+      let t := npol_replace_term (X < Y)%nat term dir1 dir2 occ false in
+      match npol_aux_dir term dir1 with
+      | P.L => apply lt_le_trans with t
+      | P.R => apply le_lt_trans with t
+      end
+    end
+  end.
 
 
 (* Make the term appears *)
 Ltac Natreplace_tac_full_id term dir1 dir2 occ :=
   match goal with
-     |-  ?G => let t1 := npol_replace_term G term dir1 dir2 occ true in 
-                match dir1 with
-                  P.L => Nat_eq_trans_l t1
-               | P.R => Nat_eq_trans_r t1
-                end; [ring | idtac]
-end.
+  | |- ?G =>
+    let t1 := npol_replace_term G term dir1 dir2 occ true in
+    match dir1 with
+    | P.L => Nat_eq_trans_l t1
+    | P.R => Nat_eq_trans_r t1
+    end; [ring | idtac]
+  end.
 
 Ltac npolrx term dir1 dir2 occ :=
-match npol_is_compare term with
-  true => Natreplace_tac_full_id term dir1 dir2 occ; [Natreplace_tac_full term dir1 dir2 occ]
-| false => 
-     let t := type of term in
-     match npol_is_compare t with true => 
-Natreplace_tac_full_id t dir1 dir2 occ; [Natreplace_tac_full t dir1 dir2 occ]
-     end 
-end.
+  match npol_is_compare term with
+  | true =>
+    Natreplace_tac_full_id term dir1 dir2 occ;
+    [Natreplace_tac_full term dir1 dir2 occ]
+  | false =>
+    let t := type of term in
+    match npol_is_compare t with
+    | true =>
+      Natreplace_tac_full_id t dir1 dir2 occ;
+      [Natreplace_tac_full t dir1 dir2 occ]
+    end
+  end.
 
 Ltac npolr term :=
-  npolrx term P.L P.L 1%Z  ||
-  npolrx term P.R P.L 1%Z ||
-  npolrx term P.L P.R 1%Z ||
-  npolrx term P.R P.R 1%Z.
+  npolrx term P.L P.L 1%Z
+  || npolrx term P.R P.L 1%Z
+  || npolrx term P.L P.R 1%Z
+  || npolrx term P.R P.R 1%Z.

--- a/NatPolS.v
+++ b/NatPolS.v
@@ -1,87 +1,75 @@
 Require Import PolSBase.
 Require Import PolAuxList.
 Require Import PolAux.
-Require Export ArithRing.
 
 Open Scope nat_scope.
 
+
 Definition Natconvert_back (e : PExpr Z) (l : list nat) : nat :=
-   convert_back Z nat 0 plus minus mult Natopp Z.abs_nat l e.
- 
+  convert_back Z nat 0 plus minus mult Natopp Z.abs_nat l e.
+
 Definition Natsimpl_minus (e : PExpr Z) :=
-   simpl_minus
+  simpl_minus
     Z Zplus Zmult Z.opp Z0 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div e.
- 
+
 Definition Natsimpl (e : PExpr Z) :=
-   simpl
+  simpl
     Z Zplus Zmult Z.opp Z0 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div e.
 
+Ltac ns term1 term2 :=
+  let term := constr:(minus term1 term2) in
+  let rfv := FV NatCst plus mult minus Natopp term (@nil nat) in
+  let fv := Trev rfv in
+  let expr1 := mkPolexpr Z NatCst plus mult minus Natopp term1 fv in
+  let expr2 := mkPolexpr Z NatCst plus mult minus Natopp term2 fv in
+  let re := (eval vm_compute in (Natsimpl_minus (PEsub expr1 expr2))) in
+  let expr3 := match re with (PEsub ?X1 _) => X1 end in
+  let expr4 := match re with (PEsub _ ?X1) => X1 end in
+  let re1 := (eval vm_compute in (Natsimpl (PEsub expr1 expr3))) in
+  let re1' :=
+      (eval
+         unfold
+         Natconvert_back, convert_back, PolAuxList.pos_nth, PolAuxList.jump,
+       PolAuxList.hd, PolAuxList.tl in (Natconvert_back (PEadd re1 expr3) fv))
+  in
+  let re1'' := (eval lazy beta in re1') in
+  let re1''' := clean_zabs re1'' in
+  let re2' :=
+      (eval
+         unfold
+         Natconvert_back, convert_back, PolAuxList.pos_nth, PolAuxList.jump,
+       PolAuxList.hd, PolAuxList.tl in (Natconvert_back (PEadd re1 expr4) fv))
+  in
+  let re2'' := (eval lazy beta in re2') in
+  let re2''' := clean_zabs re2'' in
+  replace2_tac term1 term2 re1''' re2'''; [idtac | ring | ring].
 
-Ltac
-ns term1 term2 :=
-let term := constr:(minus term1 term2) in
-let rfv := FV NatCst plus mult minus Natopp term (@nil nat) in
-let fv := Trev rfv in
-let expr1 := mkPolexpr Z NatCst plus mult minus Natopp term1 fv in
-let expr2 := mkPolexpr Z NatCst plus mult minus Natopp term2 fv in
-let re := eval vm_compute in (Natsimpl_minus (PEsub expr1 expr2)) in
-let expr3 := match re with (PEsub ?X1 _) => X1 end in
-let expr4 := match re with (PEsub _ ?X1 ) => X1 end in
-let re1 := eval vm_compute in (Natsimpl (PEsub expr1 expr3)) in
-let
- re1' :=
-  eval
-     unfold
-      Natconvert_back, convert_back,  PolAuxList.pos_nth,  PolAuxList.jump, 
-         PolAuxList.hd,  PolAuxList.tl in (Natconvert_back (PEadd re1 expr3) fv) in
-let re1'' := eval lazy beta in re1' in
-let re1''' := clean_zabs re1'' in
-let
- re2' :=
-  eval
-     unfold
-      Natconvert_back, convert_back,  PolAuxList.pos_nth,  PolAuxList.jump, 
-         PolAuxList.hd,  PolAuxList.tl in (Natconvert_back (PEadd re1 expr4) fv) in
-let re2'' := eval lazy beta in re2' in
-let re2''' := clean_zabs re2'' in
-replace2_tac term1 term2 re1''' re2'''; [idtac | ring | ring].
-(*
-(replace term with re2; [idtac | try ring]).
-*)
+Ltac npols :=
+  match goal with
+  | |- (?X1 = ?X2)%nat => ns X1 X2; apply plus_eq_compat_l
+  | |- (?X1 <> ?X2)%nat => ns X1 X2; apply plus_neg_compat_l
+  | |- lt ?X1 ?X2 => ns X1 X2; apply plus_lt_compat_l
+  | |- gt ?X1 ?X2 => ns X1 X2; apply plus_gt_compat_l
+  | |- le ?X1 ?X2 => ns X1 X2; apply plus_le_compat_l
+  | |- ge ?X1 ?X2 => ns X1 X2; apply plus_ge_compat_l
+  | _ => fail
+  end.
 
-Ltac
-npols :=
-match goal with
-| |- (?X1 = ?X2)%nat =>
-ns X1 X2; apply plus_eq_compat_l
-| |- (?X1 <> ?X2)%nat =>
-ns X1 X2; apply plus_neg_compat_l
-| |- lt ?X1 ?X2 =>
-ns X1 X2; apply plus_lt_compat_l
-| |- gt ?X1 ?X2 =>
-ns X1 X2; apply plus_gt_compat_l
-| |- le ?X1 ?X2 =>
-ns X1 X2; apply plus_le_compat_l
-| |- ge ?X1 ?X2 =>
-ns X1 X2; apply plus_ge_compat_l
-| _ => fail end.
-
-
-Ltac
-hyp_npols H :=
-generalize H;
-let tmp := fresh "tmp" in
-match (type of H) with
-   (?X1 = ?X2)%nat =>
-ns X1 X2; intros tmp; generalize (plus_reg_l _ _ _ tmp); clear H tmp; intro H
-|  (?X1 <> ?X2)%nat =>
-ns X1 X2; intros tmp; generalize (plus_neg_reg_l _ _ _ tmp); clear H tmp; intro H
-|  lt ?X1 ?X2 =>
-ns X1 X2; intros tmp; generalize (plus_lt_reg_l _ _ _ tmp); clear H tmp; intro H
-|  gt ?X1 ?X2 =>
-ns X1 X2; intros tmp; generalize (plus_gt_reg_l _ _ _ tmp); clear H tmp; intro H
-|  le ?X1 ?X2 =>
-ns X1 X2; intros tmp; generalize (plus_le_reg_l _ _ _ tmp); clear H tmp; intro H
-|  ge ?X1 ?X2 =>
-ns X1 X2; intros tmp; generalize (plus_ge_reg_l _ _ _ tmp); clear H tmp; intro H
-| _ => fail end.
+Ltac hyp_npols H :=
+  generalize H;
+  let tmp := fresh "tmp" in
+  match (type of H) with
+  | (?X1 = ?X2)%nat =>
+    ns X1 X2; intros tmp; generalize (plus_reg_l _ _ _ tmp); clear H tmp; intro H
+  | (?X1 <> ?X2)%nat =>
+    ns X1 X2; intros tmp; generalize (plus_neg_reg_l _ _ _ tmp); clear H tmp; intro H
+  | lt ?X1 ?X2 =>
+    ns X1 X2; intros tmp; generalize (plus_lt_reg_l _ _ _ tmp); clear H tmp; intro H
+  | gt ?X1 ?X2 =>
+    ns X1 X2; intros tmp; generalize (plus_gt_reg_l _ _ _ tmp); clear H tmp; intro H
+  | le ?X1 ?X2 =>
+    ns X1 X2; intros tmp; generalize (plus_le_reg_l _ _ _ tmp); clear H tmp; intro H
+  | ge ?X1 ?X2 =>
+    ns X1 X2; intros tmp; generalize (plus_ge_reg_l _ _ _ tmp); clear H tmp; intro H
+  | _ => fail
+  end.

--- a/NatSignTac.v
+++ b/NatSignTac.v
@@ -1,60 +1,64 @@
-(* Ugly tacty to resolve sign condition for Z *)
+(* Ugly tacty to resolve sign condition for nat *)
 Require Import NatAux.
 Require Export NatGroundTac.
 
 
 Ltac nsign_tac :=
- repeat (apply mult_le_compat_l || apply mult_lt_compat_l ||
-              apply mult_ge_compat_l || apply mult_gt_compat_l ||
-              apply lt_mult_0 || apply gt_mult_0); auto with arith.
+  repeat (apply mult_le_compat_l || apply mult_lt_compat_l ||
+          apply mult_ge_compat_l || apply mult_gt_compat_l ||
+          apply lt_mult_0 || apply gt_mult_0); auto with arith.
 
 Ltac hyp_nsign_tac H :=
   match type of H with
-   0 <= _ => clear H
-| ?X1 <= 0 => generalize (le_0_eq_0 _ H); clear H; intros H; subst X1
-|  ?X1 * _ <= ?X1 * _ =>
-             let s1 := fresh "NS" in
-                   (assert (s1: 0 < X1); [nsign_tac; fail |
-                   generalize (mult_le_compat_rev_l _ _ _ H s1);
-                   clear H s1; intros H])
-|   0  < ?X1 * _ =>
-              let s1 := fresh "NS" in
-                   (generalize (lt_mult_rev_0_l _ _ H);
-                    generalize (lt_mult_rev_0_r _ _ H); clear H;
-                    intros H s1; hyp_nsign_tac s1; hyp_nsign_tac H)
-|  ?X1 < 0 => absurd (~ (X1 < 0)); auto with arith
-| ?X1 * _  < ?X1 * _ =>
-              let s1 := fresh "NS" in
-                   (generalize (mult_lt_compat_rev_l1 _ _ _ H);
-                    generalize (mult_lt_compat_rev_l2 _ _ _ H); clear H;
-                    intros H s1; hyp_nsign_tac s1; hyp_nsign_tac H)
-|  ?X1 >= 0 => clear H
-| 0 >= ?X1  => generalize (le_0_eq_0 _ H); clear H; intros H; subst X1
-|  ?X1 * _ >= ?X1 * _ =>
-             let s1 := fresh "NS" in
-                   (assert (s1: 0 < X1); [nsign_tac; fail |
-                   generalize (mult_ge_compat_rev_l _ _ _ H s1);
-                   clear H s1; intros H])
-|  ?X1 * _ > 0 =>
-              let s1 := fresh "NS" in
-                   (generalize (gt_mult_rev_0_l _ _ H);
-                    generalize (gt_mult_rev_0_r _ _ H); clear H;
-                    intros H s1; hyp_nsign_tac s1; hyp_nsign_tac H)
-|  0 > ?X1 => absurd (~ (0 > X1)); auto with arith
-| ?X1 * _  > ?X1 * _ =>
-              let s1 := fresh "NS" in
-                   (generalize (mult_gt_compat_rev_l1 _ _ _ H);
-                    generalize (mult_gt_compat_rev_l2 _ _ _ H); clear H;
-                    intros H s1; hyp_nsign_tac s1; hyp_nsign_tac H)
-  |  _ => (let u := type of H in (clear H; assert (H: u); [auto with arith; fail | clear H]) || idtac)
-
-   end.
+  | 0 <= _ => clear H
+  | ?X1 <= 0 => generalize (le_0_eq_0 _ H); clear H; intros H; subst X1
+  | ?X1 * _ <= ?X1 * _ =>
+    let s1 := fresh "NS" in
+    assert (s1: 0 < X1);
+    [ nsign_tac; fail
+    | generalize (mult_le_compat_rev_l _ _ _ H s1);
+      clear H s1; intros H ]
+  |  0 < ?X1 * _ =>
+     let s1 := fresh "NS" in
+     generalize (lt_mult_rev_0_l _ _ H);
+     generalize (lt_mult_rev_0_r _ _ H); clear H;
+     intros H s1; hyp_nsign_tac s1; hyp_nsign_tac H
+  | ?X1 < 0 => absurd (~ (X1 < 0)); auto with arith
+  | ?X1 * _ < ?X1 * _ =>
+    let s1 := fresh "NS" in
+    generalize (mult_lt_compat_rev_l1 _ _ _ H);
+    generalize (mult_lt_compat_rev_l2 _ _ _ H); clear H;
+    intros H s1; hyp_nsign_tac s1; hyp_nsign_tac H
+  | ?X1 >= 0 => clear H
+  | 0 >= ?X1 => generalize (le_0_eq_0 _ H); clear H; intros H; subst X1
+  | ?X1 * _ >= ?X1 * _ =>
+    let s1 := fresh "NS" in
+    assert (s1: 0 < X1);
+    [ nsign_tac; fail
+    | generalize (mult_ge_compat_rev_l _ _ _ H s1);
+      clear H s1; intros H ]
+  | ?X1 * _ > 0 =>
+    let s1 := fresh "NS" in
+    generalize (gt_mult_rev_0_l _ _ H);
+    generalize (gt_mult_rev_0_r _ _ H); clear H;
+    intros H s1; hyp_nsign_tac s1; hyp_nsign_tac H
+  | 0 > ?X1 => absurd (~ (0 > X1)); auto with arith
+  | ?X1 * _ > ?X1 * _ =>
+    let s1 := fresh "NS" in
+    generalize (mult_gt_compat_rev_l1 _ _ _ H);
+    generalize (mult_gt_compat_rev_l2 _ _ _ H); clear H;
+    intros H s1; hyp_nsign_tac s1; hyp_nsign_tac H
+  | _ =>
+    let u := type of H in
+    (clear H; assert (H : u); [auto with arith; fail | clear H]) || idtac
+  end.
 
 (* Test *)
 Section Test.
 
 Let hyp_test : forall a b c d e,
-  0 <= a -> 0 < a -> a * b <= a * c  -> b * a <= b * c -> d <= 0 -> e < 0 -> d = 0.
+  0 <= a -> 0 < a -> a * b <= a * c -> b * a <= b * c -> d <= 0 -> e < 0 -> d = 0.
+Proof.
 intros a b c d e H H1 H2 H3 H4 H5.
 (* H should disappear *)
 hyp_nsign_tac H.
@@ -68,9 +72,9 @@ hyp_nsign_tac H4.
 hyp_nsign_tac H5.
 Qed.
 
-
 Let hyp_test1 : forall a b c d e,
-  a >= 0 -> a > 0 -> a * b > a * c  -> b * a >= b * c -> 0 >= d -> 0 > e -> d = 0.
+  a >= 0 -> a > 0 -> a * b > a * c -> b * a >= b * c -> 0 >= d -> 0 > e -> d = 0.
+Proof.
 intros a b c d e H H1 H2 H3 H4 H5.
 (* H should disappear *)
 hyp_nsign_tac H.

--- a/Natex.v
+++ b/Natex.v
@@ -1,48 +1,60 @@
 Require Import PolTac.
 
-Theorem pols_test1: forall x y, x < y ->  (x + x < y + x).
+Open Scope nat_scope.
+
+Theorem pols_test1 x y :
+  x < y -> x + x < y + x.
+Proof.
 intros.
 pols.
 auto.
 Qed.
 
-Theorem pols_test2: forall x y, y < 0 ->  (x + y < x).
-intros.
-pols.
-auto.
-Qed.
- 
-Theorem pols_test4:
- forall x y,
- x * x  < y * y ->  ((x + y) * (x + y) < 2 * (x * y + y * y)).
-intros.
-pols.
-auto.
-Qed.
- 
-Theorem pols_test5:
- forall x y z, x + y * (y + z) = 2 * z ->  2 * x + y * (y + z) = (x + z) + z.
+Theorem pols_test2 x y :
+  y < 0 -> x + y < x.
+Proof.
 intros.
 pols.
 auto.
 Qed.
 
+Theorem pols_test3 x y :
+  x * x < y * y ->
+  (x + y) * (x + y) < 2 * (x * y + y * y).
+Proof.
+intros.
+pols.
+auto.
+Qed.
 
-Theorem polf_test1: forall x y, (1 <= y -> x  <= x  * y).
+Theorem pols_test4 x y z :
+  x + y * (y + z) = 2 * z ->
+  2 * x + y * (y + z) = x + z + z.
+Proof.
+intros.
+pols.
+auto.
+Qed.
+
+Theorem polf_test1 x y :
+  1 <= y -> x <= x * y.
+Proof.
 intros.
 polf.
 Qed.
 
-Theorem polf_test2: forall x y, 0 < x -> x  <= x  * y -> 1 <= y.
-intros.
-hyp_polf H0.
+Theorem polf_test2 x y :
+  0 < x -> x <= x * y -> 1 <= y.
+Proof.
+intros H1 H2.
+hyp_polf H2.
 auto.
 Qed.
 
-
-
-Theorem polr_test1: forall x y z, (x + z) < y -> x + y + z < 2*y.
-intros x y z H.
+Theorem polr_test1 x y z :
+  x + z < y -> x + y + z < 2 * y.
+Proof.
+intros H.
 polr H.
 pols.
 auto.

--- a/Nex.v
+++ b/Nex.v
@@ -1,51 +1,61 @@
+Require Import NArith.
 Require Import PolTac.
-Require Import NAux.
 
 Open Scope N_scope.
 
-Theorem pols_test1: forall x y: N,  x < y ->  (x + x < y + x).
+Theorem pols_test1 x y :
+  x < y -> x + x < y + x.
+Proof.
 intros.
 pols.
 auto.
 Qed.
 
-Theorem pols_test2: forall x y, y < 0 ->  (x + y < x).
-intros.
-pols.
-auto.
-Qed.
- 
-Theorem pols_test4:
- forall x y,
- x * x  < y * y ->  ((x + y) * (x + y) < 2 * (x * y + y * y)).
-intros.
-pols.
-auto.
-Qed.
- 
-Theorem pols_test5:
- forall x y z, x + y * (y + z) = 2 * z ->  2 * x + y * (y + z) = (x + z) + z.
+Theorem pols_test2 x y :
+  y < 0 -> x + y < x.
+Proof.
 intros.
 pols.
 auto.
 Qed.
 
+Theorem pols_test3 x y :
+  x * x < y * y ->
+  (x + y) * (x + y) < 2 * (x * y + y * y).
+Proof.
+intros.
+pols.
+auto.
+Qed.
 
-Theorem polf_test1: forall x y, (1 <= y -> x  <= x  * y).
+Theorem pols_test4 x y z :
+  x + y * (y + z) = 2 * z ->
+  2 * x + y * (y + z) = x + z + z.
+Proof.
+intros.
+pols.
+auto.
+Qed.
+
+Theorem polf_test1 x y :
+  1 <= y -> x <= x * y.
+Proof.
 intros.
 polf.
 Qed.
 
-Theorem polf_test2: forall x y, 0 < x -> x  <= x  * y -> 1 <= y.
-intros.
-hyp_polf H0.
+Theorem polf_test2 x y :
+  0 < x -> x <= x * y -> 1 <= y.
+Proof.
+intros H1 H2.
+hyp_polf H2.
 auto.
 Qed.
 
-
-
-Theorem polr_test1: forall x y z, (x + z) < y -> x + y + z < 2*y.
-intros x y z H.
+Theorem polr_test1 x y z :
+  x + z < y -> x + y + z < 2 * y.
+Proof.
+intros H.
 polr H.
 pols.
 auto.

--- a/PolAux.v
+++ b/PolAux.v
@@ -10,13 +10,13 @@ Definition Nopp := (fun x:N => 0%N).
 
 (* Auxillary functions for Z *)
 
-Definition is_Z0 := (Zeq_bool 0).
-Definition is_Z1 := (Zeq_bool 1).
-Definition is_Zpos := (Zle_bool 0).
-Definition is_Zdiv :=
-  fun x y => if Zeq_bool x Z0 then false else Zeq_bool Z0 (Zmod y x).
-Definition Zgcd :=
- fun x y => (if (is_Zdiv x y) then x else if (is_Zdiv y x) then y else 1%Z).
+Definition is_Z0 := Zeq_bool 0.
+Definition is_Z1 := Zeq_bool 1.
+Definition is_Zpos := Zle_bool 0.
+Definition is_Zdiv x y :=
+  if Zeq_bool x Z0 then false else Zeq_bool Z0 (Zmod y x).
+Definition Zgcd x y :=
+  if is_Zdiv x y then x else if is_Zdiv y x then y else 1%Z.
 
 (* Check if a nat is a number *)
 Ltac is_NatCst p :=
@@ -24,14 +24,14 @@ Ltac is_NatCst p :=
   | O => constr:(true)
   | S ?p' => is_NatCst p'
   | _ => constr:(false)
-end.
+  end.
 
 (* Convert a Z into a nat if it is a number *)
 Ltac NatCst t :=
   match is_NatCst t with
   | false => constr:(false)
   | _ => let res := eval compute in (Z_of_nat t) in constr:(res)
-end.
+  end.
 
 
 (* Check if a number is a positive *)
@@ -41,7 +41,7 @@ Ltac is_PCst p :=
   | xO ?p' => is_PCst p'
   | xI ?p' => is_PCst p'
   | _ => constr:(false)
-end.
+  end.
 
 (* Check if a N is a number *)
 Ltac is_NCst p :=
@@ -49,114 +49,115 @@ Ltac is_NCst p :=
   | N0 => constr:(true)
   | Npos ?p' => is_PCst p'
   | _ => constr:(false)
-end.
+  end.
 
 (* Convert a Z into a nat if it is a number *)
 Ltac NCst t :=
   match is_NCst t with
   | false => constr:(false)
   | _ => let res := eval compute in (Z_of_N t) in constr:(res)
-end.
+  end.
 
 (* If a number is an integer return itself otherwise false *)
 Ltac ZCst t :=
   match t with
   | Z0 => constr:(t)
-  | Zpos ?p => match is_PCst p with
-               | false => constr:(false)
-               | _ => constr:(t)
-               end
-  | Zneg ?p => match is_PCst p with
-               | false => constr:(false)
-               | _ => constr:(t)
-               end
+  | Zpos ?p =>
+    match is_PCst p with
+    | false => constr:(false)
+    | _ => constr:(t)
+    end
+  | Zneg ?p =>
+    match is_PCst p with
+    | false => constr:(false)
+    | _ => constr:(t)
+    end
   | _ => constr:(false)
   end.
 
 (* Check if a number is an integer *)
-Ltac is_ZCst t := match t with
-                | Z0 => constr:(true)
-                | Zpos ?p => is_PCst p
-                | Zneg ?p => is_PCst p
-                | _ => constr:(false) end.
-
+Ltac is_ZCst t :=
+  match t with
+  | Z0 => constr:(true)
+  | Zpos ?p => is_PCst p
+  | Zneg ?p => is_PCst p
+  | _ => constr:(false)
+  end.
 
 (* Turn a positive into a real *)
 Fixpoint P2R (z: positive) {struct z}: R :=
   match z with
-     xH => 1%R
-  | (xO xH) => 2%R
-  | (xI xH) => 3%R
-  | (xO z1) => (2*(P2R z1))%R
-  | (xI z1) => (1+2*(P2R z1))%R
- end.
+  | xH => 1%R
+  | xO xH => 2%R
+  | xI xH => 3%R
+  | xO z1 => (2 * P2R z1)%R
+  | xI z1 => (1 + 2 * P2R z1)%R
+  end.
 
 (* Turn an integer into a real *)
 Definition Z2R (z: Z): R :=
   match z with
-     Z0 => 0%R
-  | (Zpos z1) => (P2R z1)%R
-  | (Zneg z1) => (-(P2R z1))%R
- end.
+  | Z0 => 0%R
+  | Zpos z1 => (P2R z1)%R
+  | Zneg z1 => (-(P2R z1))%R
+  end.
 
 (* Turn a R when possible into a Z *)
 Ltac RCst t :=
   match t with
-   | R0 => constr:(Z0)
-   | R1 => constr:(Zpos xH)
-   | Rplus ?e1 ?e2 =>
-       match (RCst e1) with
-        false => constr:(false)
-      | ?e3 => match (RCst e2) with
-                 false => constr:(false)
-              |  ?e4 =>  eval vm_compute in (Zplus e3  e4)
-              end
-      end
-   | Rminus ?e1 ?e2 =>
-       match (RCst e1) with
-        false => constr:(false)
-      | ?e3 => match (RCst e2) with
-                 false => constr:(false)
-              |  ?e4 => eval vm_compute in (Zminus e3  e4)
-              end
-      end
-   | Rmult ?e1 ?e2 =>
-       match (RCst e1) with
-        false => constr:(false)
-      | ?e3 => match (RCst e2) with
-                 false => constr:(false)
-              |  ?e4 => eval vm_compute in (Zmult e3  e4)
-              end
-      end
-   | Ropp ?e1 =>
-       match (RCst e1) with
-        false => constr:(false)
-      | ?e3 => eval vm_compute in (Z.opp e3)
-      end
-   | IZR ?e1 =>
-       match (ZCst e1) with
-        false => constr:(false)
-      | ?e3 => e3
-      end
-
-   | _ => constr:(false)
- end.
-
+  | R0 => constr:(Z0)
+  | R1 => constr:(Zpos xH)
+  | Rplus ?e1 ?e2 =>
+    match (RCst e1) with
+    | false => constr:(false)
+    | ?e3 => match (RCst e2) with
+            | false => constr:(false)
+            | ?e4 =>  eval vm_compute in (Zplus e3  e4)
+            end
+    end
+  | Rminus ?e1 ?e2 =>
+    match (RCst e1) with
+    | false => constr:(false)
+    | ?e3 => match (RCst e2) with
+            | false => constr:(false)
+            |  ?e4 => eval vm_compute in (Zminus e3  e4)
+            end
+    end
+  | Rmult ?e1 ?e2 =>
+    match (RCst e1) with
+    | false => constr:(false)
+    | ?e3 => match (RCst e2) with
+            | false => constr:(false)
+            | ?e4 => eval vm_compute in (Zmult e3  e4)
+            end
+    end
+  | Ropp ?e1 =>
+    match (RCst e1) with
+    | false => constr:(false)
+    | ?e3 => eval vm_compute in (Z.opp e3)
+    end
+  | IZR ?e1 =>
+    match (ZCst e1) with
+    | false => constr:(false)
+    | ?e3 => e3
+    end
+  | _ => constr:(false)
+  end.
 
 (* Remove the Z.abs_nat of a number, unfortunately stops at
    the first Z.abs_nat x where x is not a number *)
 
 Ltac clean_zabs term :=
   match term with
-   context id [(Z.abs_nat ?X)] =>
-     match is_ZCst X with
-       true =>
-         let x := eval vm_compute in (Z.abs_nat X) in
-         let y := context id [x] in
-           clean_zabs y
-     | false => term
-     end
-    | _ => term
+  | context id [(Z.abs_nat ?X)] =>
+    match is_ZCst X with
+    | true =>
+      let x := (eval vm_compute in (Z.abs_nat X)) in
+      let y := context id [x] in
+      clean_zabs y
+    | false => term
+    end
+  | _ => term
   end.
 
 (* Remove the Z.abs_N of a number, unfortunately stops at
@@ -164,15 +165,15 @@ Ltac clean_zabs term :=
 
 Ltac clean_zabs_N term :=
   match term with
-   context id [(Z.abs_N ?X)] =>
-     match is_ZCst X with
-       true =>
-         let x := eval vm_compute in (Z.abs_N X) in
-         let y := context id [x] in
-           clean_zabs_N y
-     | false => term
-     end
-    | _ => term
+  | context id [(Z.abs_N ?X)] =>
+    match is_ZCst X with
+    | true =>
+      let x := (eval vm_compute in (Z.abs_N X)) in
+      let y := context id [x] in
+      clean_zabs_N y
+    | false => term
+    end
+  | _ => term
   end.
 
 (* Equality test for Ltac *)
@@ -182,64 +183,56 @@ Ltac eqterm t1 t2 :=
 
 (* For replace *)
 
-Theorem trans_equal_r : forall (A: Set) (x y z:A), y = z -> x = y -> x = z.
-intros; apply trans_equal with y; auto.
-Qed.
+Theorem trans_equal_r : forall (A : Set) (x y z :A), y = z -> x = y -> x = z.
+Proof. intros; apply trans_equal with y; auto. Qed.
 
 (* Theorems for nat *)
 
 Open Scope nat_scope.
 
 Theorem plus_eq_compat_l: forall a b c, b = c -> a + b = a + c.
-intros; apply f_equal2 with (f := plus); auto.
-Qed.
+Proof. intros; apply f_equal2 with (f := plus); auto. Qed.
 
 Theorem plus_neg_compat_l: forall a b c, b <> c -> a + b <> a + c.
-intros a b c H H1; case H.
-apply plus_reg_l with a; auto.
-Qed.
+Proof. intros a b c H H1; case H; apply plus_reg_l with a; auto. Qed.
 
 Theorem plus_ge_compat_l: forall n m p : nat, n >= m -> p + n >= p + m.
-intros n m p H; unfold ge; apply plus_le_compat_l; auto.
-Qed.
+Proof. intros n m p H; unfold ge; apply plus_le_compat_l; auto. Qed.
 
 Theorem plus_neg_reg_l: forall a b c,  a + b <> a + c -> b <> c.
-intros a b c H H1; case H; subst; auto.
-Qed.
+Proof. intros a b c H H1; case H; subst; auto. Qed.
 
 Theorem plus_ge_reg_l: forall n m p : nat, p + n >= p + m -> n >= m.
-intros n m p H; unfold ge; apply plus_le_reg_l with p; auto.
-Qed.
+Proof. intros n m p H; unfold ge; apply plus_le_reg_l with p; auto. Qed.
 
 (* For replace *)
-Theorem eq_lt_trans_l : forall x y z, (x = z) -> (x < y) -> (z < y).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_lt_trans_r : forall x y z, (y = z) -> (x < y) -> (x < z).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_gt_trans_l : forall x y z, (x = z) -> (x > y) -> (z > y).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_gt_trans_r : forall x y z, (y = z) -> (x > y) -> (x > z).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_le_trans_l : forall x y z, (x = z) -> (x <= y) -> (z <= y).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_le_trans_r : forall x y z, (y = z) -> (x <= y) -> (x <= z).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_ge_trans_l : forall x y z, (x = z) -> (x >= y) -> (z >= y).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_ge_trans_r : forall x y z, (y = z) -> (x >= y) -> (x >= z).
-intros x y z H; rewrite H; auto.
-Qed.
 
-Theorem ge_trans: forall x y z, (x >= z) -> (z >= y) -> (x >= y).
-intros x y z H1 H2; red; apply le_trans with z; auto.
-Qed.
+Theorem eq_lt_trans_l : forall x y z, x = z -> x < y -> z < y.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_lt_trans_r : forall x y z, y = z -> x < y -> x < z.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_gt_trans_l : forall x y z, x = z -> x > y -> z > y.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_gt_trans_r : forall x y z, y = z -> x > y -> x > z.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_le_trans_l : forall x y z, x = z -> x <= y -> z <= y.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_le_trans_r : forall x y z, y = z -> x <= y -> x <= z.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_ge_trans_l : forall x y z, x = z -> x >= y -> z >= y.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_ge_trans_r : forall x y z, y = z -> x >= y -> x >= z.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem ge_trans: forall x y z, x >= z -> z >= y -> x >= y.
+Proof. intros x y z H1 H2; red; apply le_trans with z; auto. Qed.
 
 Close Scope nat_scope.
 
@@ -248,81 +241,65 @@ Close Scope nat_scope.
 Open Scope N_scope.
 
 Theorem Nplus_eq_compat_l: forall a b c, b = c -> a + b = a + c.
-intros; apply f_equal2 with (f:= Nplus); auto.
-Qed.
+Proof. intros; apply f_equal2 with (f:= Nplus); auto. Qed.
 
 Theorem Nplus_neg_compat_l: forall a b c, b <> c -> a + b <> a + c.
-intros a b c H1 H2; case H1.
-apply Nplus_reg_l with a; auto.
-Qed.
+Proof. intros a b c H1 H2; case H1; apply Nplus_reg_l with a; auto. Qed.
 
 Theorem Nplus_lt_compat_l: forall n m p, n < m -> p + n < p + m.
-intros; to_nat; auto with arith.
-Qed.
+Proof. intros; to_nat; auto with arith. Qed.
 
 Theorem Nplus_gt_compat_l: forall n m p, n > m -> p + n > p + m.
-intros; to_nat; auto with arith.
-Qed.
+Proof. intros; to_nat; auto with arith. Qed.
 
 Theorem Nplus_le_compat_l: forall n m p, n <= m -> p + n <= p + m.
-intros; to_nat; auto with arith.
-Qed.
+Proof. intros; to_nat; auto with arith. Qed.
 
 Theorem Nplus_ge_compat_l: forall n m p, n >= m -> p + n >= p + m.
-intros; to_nat; auto with arith.
-Qed.
+Proof. intros; to_nat; auto with arith. Qed.
 
 Theorem Nplus_neg_reg_l: forall a b c,  a + b <> a + c -> b <> c.
-intros a b c H H1; case H; apply f_equal2 with (f:= Nplus); auto.
-Qed.
+Proof. intros a b c H H1; case H; apply f_equal2 with (f:= Nplus); auto. Qed.
 
 Theorem Nplus_lt_reg_l: forall n m p, p + n < p + m -> n < m.
-intros; to_nat; apply plus_lt_reg_l with nn1; auto with arith.
-Qed.
+Proof. intros; to_nat; apply plus_lt_reg_l with nn1; auto with arith. Qed.
 
 Theorem Nplus_gt_reg_l: forall n m p, p + n > p + m -> n > m.
-intros; to_nat; apply plus_gt_reg_l with nn1; auto with arith.
-Qed.
+Proof. intros; to_nat; apply plus_gt_reg_l with nn1; auto with arith. Qed.
 
 Theorem Nplus_le_reg_l: forall n m p, p + n <= p + m -> n <= m.
-intros; to_nat; apply plus_le_reg_l with nn1; auto with arith.
-Qed.
+Proof. intros; to_nat; apply plus_le_reg_l with nn1; auto with arith. Qed.
 
 Theorem Nplus_ge_reg_l: forall n m p, p + n >= p + m -> n >= m.
-intros; to_nat; apply plus_ge_reg_l with nn1; auto with arith.
-Qed.
+Proof. intros; to_nat; apply plus_ge_reg_l with nn1; auto with arith. Qed.
 
 (* For replace *)
-Theorem Neq_lt_trans_l : forall x y z, (x = z) -> (x < y) -> (z < y).
-intros; subst; auto.
-Qed.
+Theorem Neq_lt_trans_l : forall x y z, x = z -> x < y -> z < y.
+Proof. intros; subst; auto. Qed.
 
-Theorem Neq_lt_trans_r : forall x y z, (y = z) -> (x < y) -> (x < z).
-intros; subst; auto.
-Qed.
+Theorem Neq_lt_trans_r : forall x y z, y = z -> x < y -> x < z.
+Proof. intros; subst; auto. Qed.
 
-Theorem Neq_gt_trans_l : forall x y z, (x = z) -> (x > y) -> (z > y).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem Neq_gt_trans_r : forall x y z, (y = z) -> (x > y) -> (x > z).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem Neq_le_trans_l : forall x y z, (x = z) -> (x <= y) -> (z <= y).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem Neq_le_trans_r : forall x y z, (y = z) -> (x <= y) -> (x <= z).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem Neq_ge_trans_l : forall x y z, (x = z) -> (x >= y) -> (z >= y).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem Neq_ge_trans_r : forall x y z, (y = z) -> (x >= y) -> (x >= z).
-intros x y z H; rewrite H; auto.
-Qed.
+Theorem Neq_gt_trans_l : forall x y z, x = z -> x > y -> z > y.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem Neq_gt_trans_r : forall x y z, y = z -> x > y -> x > z.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem Neq_le_trans_l : forall x y z, x = z -> x <= y -> z <= y.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem Neq_le_trans_r : forall x y z, y = z -> x <= y -> x <= z.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem Neq_ge_trans_l : forall x y z, x = z -> x >= y -> z >= y.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem Neq_ge_trans_r : forall x y z, y = z -> x >= y -> x >= z.
+Proof. intros x y z H; rewrite H; auto. Qed.
 
 Theorem Nge_trans: forall x y z, (x >= z) -> (z >= y) -> (x >= y).
-intros; to_nat; red; apply le_trans with nn1; auto with arith.
-Qed.
+Proof. intros; to_nat; red; apply le_trans with nn1; auto with arith. Qed.
 
 Close Scope N_scope.
 
@@ -332,34 +309,32 @@ Open Scope Z_scope.
 
 (* For replace *)
 
-Theorem eq_Zlt_trans_l : forall x y z, (x = z) -> (x < y) -> (z < y).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_Zlt_trans_r : forall x y z, (y = z) -> (x < y) -> (x < z).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_Zgt_trans_l : forall x y z, (x = z) -> (x > y) -> (z > y).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_Zgt_trans_r : forall x y z, (y = z) -> (x > y) -> (x > z).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_Zle_trans_l : forall x y z, (x = z) -> (x <= y) -> (z <= y).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_Zle_trans_r : forall x y z, (y = z) -> (x <= y) -> (x <= z).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_Zge_trans_l : forall x y z, (x = z) -> (x >= y) -> (z >= y).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_Zge_trans_r : forall x y z, (y = z) -> (x >= y) -> (x >= z).
-intros x y z H; rewrite H; auto.
-Qed.
+Theorem eq_Zlt_trans_l : forall x y z, x = z -> x < y -> z < y.
+Proof. intros x y z H; rewrite H; auto. Qed.
 
-Theorem Zge_trans: forall x y z, (x >= z) -> (z >= y) -> (x >= y).
-intros x y z H1 H2; red; apply Zge_trans with z; auto.
-Qed.
+Theorem eq_Zlt_trans_r : forall x y z, y = z -> x < y -> x < z.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_Zgt_trans_l : forall x y z, x = z -> x > y -> z > y.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_Zgt_trans_r : forall x y z, y = z -> x > y -> x > z.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_Zle_trans_l : forall x y z, x = z -> x <= y -> z <= y.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_Zle_trans_r : forall x y z, y = z -> x <= y -> x <= z.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_Zge_trans_l : forall x y z, x = z -> x >= y -> z >= y.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_Zge_trans_r : forall x y z, y = z -> x >= y -> x >= z.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem Zge_trans: forall x y z, x >= z -> z >= y -> x >= y.
+Proof. intros x y z H1 H2; red; apply Zge_trans with z; auto. Qed.
 
 Close Scope Z_scope.
 
@@ -369,71 +344,71 @@ Open Scope R_scope.
 
 (* For replace *)
 
-Theorem eq_Rlt_trans_l : forall x y z, (x = z) -> (x < y) -> (z < y).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_Rlt_trans_r : forall x y z, (y = z) -> (x < y) -> (x < z).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_Rgt_trans_l : forall x y z, (x = z) -> (x > y) -> (z > y).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_Rgt_trans_r : forall x y z, (y = z) -> (x > y) -> (x > z).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_Rle_trans_l : forall x y z, (x = z) -> (x <= y) -> (z <= y).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_Rle_trans_r : forall x y z, (y = z) -> (x <= y) -> (x <= z).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_Rge_trans_l : forall x y z, (x = z) -> (x >= y) -> (z >= y).
-intros x y z H; rewrite H; auto.
-Qed.
-Theorem eq_Rge_trans_r : forall x y z, (y = z) -> (x >= y) -> (x >= z).
-intros x y z H; rewrite H; auto.
-Qed.
+Theorem eq_Rlt_trans_l : forall x y z, x = z -> x < y -> z < y.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_Rlt_trans_r : forall x y z, y = z -> x < y -> x < z.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_Rgt_trans_l : forall x y z, x = z -> x > y -> z > y.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_Rgt_trans_r : forall x y z, y = z -> x > y -> x > z.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_Rle_trans_l : forall x y z, x = z -> x <= y -> z <= y.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_Rle_trans_r : forall x y z, y = z -> x <= y -> x <= z.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_Rge_trans_l : forall x y z, x = z -> x >= y -> z >= y.
+Proof. intros x y z H; rewrite H; auto. Qed.
+
+Theorem eq_Rge_trans_r : forall x y z, y = z -> x >= y -> x >= z.
+Proof. intros x y z H; rewrite H; auto. Qed.
 
 Theorem Rge_trans: forall x y z, (x >= z) -> (z >= y) -> (x >= y).
-intros x y z H1 H2; red; apply Rge_trans with z; auto.
-Qed.
+Proof. intros x y z H1 H2; red; apply Rge_trans with z; auto. Qed.
 
 (* For RGroundTac *)
 
-
-Theorem Z2R_correct: forall p, (Z2R p) = (IZR p).
+Theorem Z2R_correct: forall p, Z2R p = IZR p.
+Proof.
 intros p; case p; auto.
 intros p1; elim p1; auto.
-intros p2 Rec; pattern (Zpos (xI p2)) at 2; replace (Zpos (xI p2)) with (2 * (Zpos p2) +1)%Z; auto with zarith.
+intros p2 Rec; pattern (Zpos (xI p2)) at 2;
+  replace (Zpos (xI p2)) with (2 * (Zpos p2) +1)%Z by auto.
 rewrite plus_IZR; rewrite mult_IZR; rewrite <- Rec.
-simpl Z2R; simpl IZR; case p2; intros; simpl (P2R 1);ring.
-intros p2 Rec; pattern (Zpos (xO p2)) at 2; replace (Zpos (xO p2)) with (2 * (Zpos p2))%Z; auto with zarith.
+simpl Z2R; simpl IZR; case p2; intros; simpl (P2R 1); ring.
+intros p2 Rec; pattern (Zpos (xO p2)) at 2;
+  replace (Zpos (xO p2)) with (2 * (Zpos p2))%Z by auto.
 rewrite mult_IZR; rewrite <- Rec.
 simpl Z2R; simpl IZR; case p2; intros; simpl (P2R 1); ring.
 intros p1; elim p1; auto.
-intros p2 Rec; pattern (Zneg (xI p2)) at 2; replace (Zneg (xI p2)) with ((2 * (Zneg p2) +  -1))%Z; auto with zarith.
+intros p2 Rec; pattern (Zneg (xI p2)) at 2;
+  replace (Zneg (xI p2)) with ((2 * (Zneg p2) +  -1))%Z by auto.
 rewrite plus_IZR; rewrite mult_IZR; rewrite <- Rec.
 simpl Z2R; simpl IZR; case p2; intros; simpl (P2R 1); ring.
-intros p2 Rec; pattern (Zneg (xO p2)) at 2; replace (Zneg (xO p2)) with (2 * (Zneg p2))%Z; auto with zarith.
+intros p2 Rec; pattern (Zneg (xO p2)) at 2;
+  replace (Zneg (xO p2)) with (2 * (Zneg p2))%Z by auto.
 rewrite mult_IZR; rewrite <- Rec.
 simpl Z2R; simpl IZR; case p2; intros; simpl (P2R 1); ring.
 Qed.
 
 Theorem Z2R_le: forall p q, (p <= q)%Z -> (Z2R p <= Z2R q)%R.
-intros p q; repeat rewrite Z2R_correct; intros; apply IZR_le; auto.
-Qed.
+Proof. intros p q; repeat rewrite Z2R_correct; intros; apply IZR_le; auto. Qed.
 
 Theorem Z2R_lt: forall p q, (p < q)%Z -> (Z2R p < Z2R q)%R.
-intros p q; repeat rewrite Z2R_correct; intros; apply IZR_lt; auto.
-Qed.
+Proof. intros p q; repeat rewrite Z2R_correct; intros; apply IZR_lt; auto. Qed.
 
 Theorem Z2R_ge: forall p q, (p >= q)%Z -> (Z2R p >= Z2R q)%R.
-intros p q; repeat rewrite Z2R_correct; intros; apply IZR_ge; auto.
-Qed.
+Proof. intros p q; repeat rewrite Z2R_correct; intros; apply IZR_ge; auto. Qed.
 
 Theorem Z2R_gt: forall p q, (p > q)%Z -> (Z2R p > Z2R q)%R.
+Proof.
 intros p q; repeat rewrite Z2R_correct; intros; red; apply IZR_lt;
-apply Z.gt_lt; auto.
+  apply Z.gt_lt; auto.
 Qed.
 
 Close Scope R_scope.

--- a/PolAuxList.v
+++ b/PolAuxList.v
@@ -3,39 +3,39 @@ Require Import ZArith.
 
 Section AUXLIST.
 
- Variable A:Set.
- Variable default:A.
+Variable A : Set.
+Variable default : A.
 
+Definition hd l := match l with hd :: _ => hd | _ => default end.
 
- Definition hd l := match l with hd :: _ => hd | _ => default end. 
+Definition tl (l : list A) := match l with _ :: tl => tl | _ => nil end.
 
- Definition tl (l: list A) := match l with _ :: tl => tl | _ => nil end. 
-
- Fixpoint jump (p:positive) (l:list A) {struct p} : (list A) :=
+Fixpoint jump (p : positive) (l : list A) {struct p} : (list A) :=
   match p with
   | xH => tl l
   | xO p => jump p (jump p l)
   | xI p  => jump p (jump p (tl l))
   end.
 
- Fixpoint pos_nth (p:positive) (l:list A) {struct p} : A:=
+Fixpoint pos_nth (p : positive) (l : list A) {struct p} : A :=
   match p with
   | xH => hd l
   | xO p => pos_nth p (jump p l)
   | xI p => pos_nth p (jump p (tl l))
-  end. 
+  end.
 
 End AUXLIST.
 
 Arguments pos_nth [A] _ _ _.
 
- Ltac Trev l :=  
+Ltac Trev l :=
   let rec rev_append rev l :=
-   match l with
-   |  nil  => constr:(rev)
-   | (cons ?h ?t) => let rev := constr:(cons h rev) in rev_append rev t 
-   end in
- match type of l with
-  (list ?X) => rev_append (@nil X) l
- end.
-
+      match l with
+      |  nil  => constr:(rev)
+      | (cons ?h ?t) => let rev := constr:(cons h rev) in
+                       rev_append rev t
+      end
+  in
+  match type of l with
+  | (list ?X) => rev_append (@nil X) l
+  end.

--- a/PolFBase.v
+++ b/PolFBase.v
@@ -6,271 +6,288 @@ Section PolFactorSimpl.
 Variable C : Set.
 
 (* Usual operations *)
-Variable Cplus : C -> C ->  C.
-Variable Cmul : C -> C ->  C.
-Variable Cop : C ->  C.
+Variable Cplus : C -> C -> C.
+Variable Cmul : C -> C -> C.
+Variable Cop : C -> C.
 
 (* Constant *)
 Variable C0 : C.
 Variable C1 : C.
 
 (* Test to 1 *)
-Variable isC1 : C ->  bool.
+Variable isC1 : C -> bool.
 
 (* Test to 0 *)
-Variable isC0 : C ->  bool.
+Variable isC0 : C -> bool.
 
 (* Test if positive *)
-Variable isPos : C ->  bool.
+Variable isPos : C -> bool.
 
 (* Divisibility *)
-Variable Cdivide : C -> C ->  bool.
+Variable Cdivide : C -> C -> bool.
 
 (* Division *)
-Variable Cdiv : C -> C ->  C.
+Variable Cdiv : C -> C -> C.
 
 (* Gcd *)
 Variable Cgcd: C -> C -> C.
 
 (* Test if the difference of two terms is zero *)
-Definition is_eq :=  fun x y => 
-  let r :=  simpl C Cplus Cmul Cop C0 C1 isC1 isC0 isPos Cdivide Cdiv (PEsub x y) in
-   match r with
-     PEc c  => isC0 c
-  |  _          => false
+Definition is_eq  (x y : PExpr C) : bool :=
+  let r := simpl C Cplus Cmul Cop C0 C1 isC1 isC0 isPos Cdivide Cdiv (PEsub x y) in
+  match r with
+  | PEc c => isC0 c
+  | _ => false
   end.
-(*
-Axiom is_eq: (PExpr C) -> (PExpr C) -> bool.
-*)
 
 (* Test if the sum of two term is zero *)
 
-Definition is_op :=  fun x y => 
-  let r :=  simpl C Cplus Cmul Cop C0 C1 isC1 isC0 isPos Cdivide Cdiv (PEadd x y) in
-   match r with
-     PEc c  => isC0 c
-  |  _          => false
+Definition is_op (x y : PExpr C) : bool :=
+  let r := simpl C Cplus Cmul Cop C0 C1 isC1 isC0 isPos Cdivide Cdiv (PEadd x y) in
+  match r with
+  | PEc c => isC0 c
+  | _ => false
   end.
 
-(* 
-Axiom is_op: (PExpr C) -> (PExpr C) -> bool.
-*)
-
-Definition test_in :=
-   fun x y => 
-        match x, y with
-          PEc c1, PEc c2 =>  if (isC1 (Cgcd c1 c2)) then false else true
-         | _ , _ => match (is_eq x y) with true => true | false => is_op x y end
-        end.
+Definition test_in (x y : PExpr C) : bool :=
+  match x, y with
+  | PEc c1, PEc c2 => if (isC1 (Cgcd c1 c2)) then false else true
+  | _ , _ => match (is_eq x y) with true => true | false => is_op x y end
+  end.
 
 (* Return the first factor of a sum *)
-Fixpoint first_factor (e: PExpr C) : PExpr C :=
-match e with
-  PEadd e1 _  =>  first_factor e1
-| PEsub e1 _  =>  first_factor e1
-| PEopp e1     =>  first_factor e1
-| _                    =>  e
-end.
+Fixpoint first_factor (e : PExpr C) : PExpr C :=
+  match e with
+  | PEadd e1 _ => first_factor e1
+  | PEsub e1 _ => first_factor e1
+  | PEopp e1 => first_factor e1
+  | _ => e
+  end.
 
 (* Split a product in list of products *)
-Fixpoint split_factor (e: PExpr C) : list (PExpr C) :=
-match e with
-  PEmul e1 e2  =>  (split_factor e1)++(split_factor e2)
-| PEopp e1        =>  match  (split_factor e1) with (_::nil) => e::nil | l1 => l1 end 
-| _                    =>  e::nil
-end.
+Fixpoint split_factor (e : PExpr C) : list (PExpr C) :=
+  match e with
+  | PEmul e1 e2 => split_factor e1 ++ split_factor e2
+  | PEopp e1 => match split_factor e1 with _::nil => e::nil | l1 => l1 end
+  | _ => e::nil
+  end.
 
 (* Split a product in list of products *)
-Fixpoint split_factors (e: PExpr C) : list (list (PExpr C)) :=
-match e with
-  PEadd e1 e2  =>  (split_factors e1)++(split_factors e2)
-| PEsub e1 e2  =>  (split_factors e1)++(split_factors e2)
-| PEopp e1        =>  match  (split_factors e1) with ((_::nil)::nil) => (e::nil)::nil | l1 => l1 end 
-| _                    =>  (split_factor e)::nil
-end.
+Fixpoint split_factors (e : PExpr C) : list (list (PExpr C)) :=
+  match e with
+  | PEadd e1 e2 => split_factors e1 ++ split_factors e2
+  | PEsub e1 e2 => split_factors e1 ++ split_factors e2
+  | PEopp e1 =>
+    match split_factors e1 with (_::nil)::nil => (e::nil)::nil | l1 => l1 end
+  | _ => split_factor e::nil
+  end.
 
 (* Application on an optional type *)
-Definition oapp:= 
-   fun (A B:Set) (a: A) (f: A -> B -> B) (l: option B) => 
-       match l with Some l1 => Some (f a l1) | _ => None end.
+Definition oapp (A B : Set) (a : A) (f : A -> B -> B) (l : option B) :=
+  match l with Some l1 => Some (f a l1) | _ => None end.
 
-Let ocons := fun  x => oapp _ _ x (@cons (PExpr C)).
+Let ocons := fun x => oapp _ _ x (@cons (PExpr C)).
 
 (* Remove an element in a list *)
-Fixpoint remove_elem (e: PExpr C) (l: list (PExpr C)) {struct l}: option (list (PExpr C)) :=
-match l with
-   nil   =>  None
-| cons e1 l1  =>  if (test_in e e1) then Some l1 else (ocons e1 (remove_elem e l1))
-end.
+Fixpoint remove_elem (e: PExpr C) (l: list (PExpr C)) {struct l}
+  : option (list (PExpr C)) :=
+  match l with
+  | nil => None
+  | cons e1 l1 => if (test_in e e1) then Some l1 else (ocons e1 (remove_elem e l1))
+  end.
 
-Let oconst := fun (A:Set) x =>  oapp _ _ x (fun x (y: A * list (PExpr C)) => let (v1,l1) := y in (v1, x::l1)).
-
+Let oconst (A : Set) (x : PExpr C) :=
+  oapp _ _ x (fun x (y : A * list (PExpr C)) =>
+                let (v1,l1) := y in (v1, x::l1)).
 
 (* Remove a constant in a list *)
-Fixpoint remove_constant (c: C) (l: list (PExpr C)) {struct l}: option (C * list (PExpr C)) :=
-match l with
-   nil   =>  None
-| cons (PEc c1)  l1  =>  if (isC1 (Cgcd c c1)) then oconst  _ (PEc c1) (remove_constant c l1)
-                                                                             else Some (Cgcd c c1, cons (PEc (Cdiv c (Cgcd c c1))) l1)
-| cons c1 l1 => oconst _  c1 (remove_constant c l1)
-end.
-        
+Fixpoint remove_constant (c : C) (l : list (PExpr C)) {struct l}
+  : option (C * list (PExpr C)) :=
+  match l with
+  | nil => None
+  | cons (PEc c1) l1 =>
+    if isC1 (Cgcd c c1)
+    then oconst _ (PEc c1) (remove_constant c l1)
+    else Some (Cgcd c c1, cons (PEc (Cdiv c (Cgcd c c1))) l1)
+  | cons c1 l1 => oconst _ c1 (remove_constant c l1)
+  end.
+
 (* Strip the element that are not in the list *)
 
 Fixpoint strip (l1 l2: list (PExpr C)) {struct l1} : list (PExpr C) :=
-match l1 with
-  nil => nil
-| cons (PEc c) l3 => match remove_constant c l2 with 
-                                     None => strip l3 l2
-                                  | Some (c1, l4) => cons (PEc c1) (strip l3 l4)
-                                   end
-| cons e l3 =>  match remove_elem e l2 with 
-                                     None => strip l3 l2
-                                  | Some l4 => cons e (strip l3 l4)
-                           end
-end.
+  match l1 with
+  | nil => nil
+  | cons (PEc c) l3 =>
+    match remove_constant c l2 with
+    | None => strip l3 l2
+    | Some (c1, l4) => cons (PEc c1) (strip l3 l4)
+    end
+  | cons e l3 =>
+    match remove_elem e l2 with
+    | None => strip l3 l2
+    | Some l4 => cons e (strip l3 l4)
+    end
+  end.
 
 (* iter strip for all the element l2 *)
-Fixpoint delta (l1: list (PExpr C))  (l2:  list (list (PExpr C))) {struct l2} : list (PExpr C) :=
-match l2 with
-nil => l1
-| cons l l4 => match strip l1 l with 
-                         nil  => nil
-                       | l3 => delta l3 l4
-                      end
-end.
+Fixpoint delta (l1: list (PExpr C)) (l2: list (list (PExpr C))) {struct l2}
+  : list (PExpr C) :=
+  match l2 with
+  | nil => l1
+  | cons l l4 =>
+    match strip l1 l with
+    | nil => nil
+    | l3 => delta l3 l4
+    end
+  end.
 
 Let mkMul := mkPEmul C Cmul Cop C0 isC1 isC0.
-Let mkOpp := mkPEopp  C Cop.
+Let mkOpp := mkPEopp C Cop.
 Let mkAdd := mkPEadd C Cplus Cmul Cop C0 isC1 isC0 isPos.
 Let mkSub := mkPEsub C Cplus Cmul Cop C0 isC1 isC0 isPos.
 
-
 (* Remove an element in a list *)
-Fixpoint subst_elem (e: PExpr C) (l: list (PExpr C)) {struct l}: option (bool * list (PExpr C)) :=
-match l with
-   nil   =>  None
-| cons e1 l1  =>  if is_eq e e1 then Some (true, l1) else
-                             if is_op e e1 then Some (false, l1) else  (oconst _ e1 (subst_elem e l1))
-end.
+Fixpoint subst_elem (e: PExpr C) (l: list (PExpr C)) {struct l}
+  : option (bool * list (PExpr C)) :=
+  match l with
+  | nil => None
+  | cons e1 l1 =>
+    if is_eq e e1 then Some (true, l1) else
+      if is_op e e1 then Some (false, l1) else
+        (oconst _ e1 (subst_elem e l1))
+  end.
 
 
 (* Remove a constant in a list *)
-Fixpoint subst_constant (c: C) (l: list (PExpr C)) {struct l}: option (C * list (PExpr C)) :=
-match l with
-   nil   =>  None
-| cons (PEc c1)  l1  =>  if (Cdivide c1 c) then  Some (Cdiv c c1,  l1)
-                                                                      else oconst _ (PEc c1) (subst_constant c l1)
-| cons e1 l1 => oconst _ e1 (subst_constant c l1)
-end.
-    
+Fixpoint subst_constant (c : C) (l : list (PExpr C)) {struct l}
+  : option (C * list (PExpr C)) :=
+  match l with
+  | nil => None
+  | cons (PEc c1) l1 =>
+    if (Cdivide c1 c)
+    then Some (Cdiv c c1, l1)
+    else oconst _ (PEc c1) (subst_constant c l1)
+  | cons e1 l1 => oconst _ e1 (subst_constant c l1)
+  end.
 
 (* Split a product in list of products *)
-Fixpoint subst_one_factor (e: PExpr C) (l: list (PExpr C)) {struct e}: PExpr C * list (PExpr C) :=
-match e with
-  PEmul e1 e2  => let (e3, l1) := subst_one_factor e1 l in
-                                let (e4, l2) := subst_one_factor e2 l1 in
-                                  (mkMul e3 e4, l2)
-| PEopp e1        =>  let (e3, l1) := subst_one_factor e1 l in
-                                     (mkOpp e3, l1) 
-| PEc c               => match subst_constant c l with
-                                     None => (e, l)
-                                 |   Some (c1, l1) => (PEc c1, l1)
-                                 end 
-| _ =>  match subst_elem e l with
-              None => (e, l) 
-           | Some (true, l1) => (PEc C1, l1)
-           | Some (false, l1) => (PEc (Cop C1), l1)
-           end
-end.
+Fixpoint subst_one_factor (e: PExpr C) (l: list (PExpr C)) {struct e}
+  : PExpr C * list (PExpr C) :=
+  match e with
+  | PEmul e1 e2 =>
+    let (e3, l1) := subst_one_factor e1 l in
+    let (e4, l2) := subst_one_factor e2 l1 in
+    (mkMul e3 e4, l2)
+  | PEopp e1 =>
+    let (e3, l1) := subst_one_factor e1 l in
+    (mkOpp e3, l1)
+  | PEc c =>
+    match subst_constant c l with
+    | None => (e, l)
+    | Some (c1, l1) => (PEc c1, l1)
+    end
+  | _ =>
+    match subst_elem e l with
+    | None => (e, l)
+    | Some (true, l1) => (PEc C1, l1)
+    | Some (false, l1) => (PEc (Cop C1), l1)
+    end
+  end.
 
 (* Return the first factor of a sum *)
 Fixpoint subst_factor (l: list (PExpr C)) (e: PExpr C) {struct e} : PExpr C :=
-match e with
-  PEadd e1 e2  =>  mkAdd (subst_factor l e1) (subst_factor l e2)
-| PEsub e1 e2=>  mkSub (subst_factor l e1) (subst_factor l e2)
-| PEopp e1  =>   mkOpp (subst_factor l e1)
-| _                 => fst (subst_one_factor e l) 
-end.
+  match e with
+  | PEadd e1 e2 => mkAdd (subst_factor l e1) (subst_factor l e2)
+  | PEsub e1 e2=> mkSub (subst_factor l e1) (subst_factor l e2)
+  | PEopp e1 => mkOpp (subst_factor l e1)
+  | _ => fst (subst_one_factor e l)
+  end.
 
-Definition get_delta := fun e => match split_factors e with
-                                                        l1::l => delta l1 l
-                                                      | _ => nil
-                                                      end.
+Definition get_delta (e : PExpr C) : list (PExpr C) :=
+  match split_factors e with
+  | l1::l => delta l1 l
+  | _ => nil
+  end.
 
-Fixpoint mkProd (l: (list (PExpr C))) {struct l} : (PExpr C) :=
-   match l with 
-      nil => (PEc C1)
+Fixpoint mkProd (l : list (PExpr C)) {struct l} : (PExpr C) :=
+  match l with
+  | nil => PEc C1
   | e::nil => e
   | e::l1 => mkMul e (mkProd l1)
   end.
 
-Fixpoint find_trivial_factor (e: PExpr C) (l: list (list (PExpr C))) {struct l}: PExpr C :=
+Fixpoint find_trivial_factor (e : PExpr C) (l : list (list (PExpr C))) {struct l}
+  : PExpr C :=
   match l with
-     l1::ll2 => let e1 := mkProd l1 in
-                     let e2 := simpl C Cplus Cmul Cop C0 C1 isC1 isC0 isPos Cdivide Cdiv (mkSub e e1) in
-                     match subst_elem e2 l1 with
-                       None => find_trivial_factor e ll2
-                     | Some (true, l2) =>  PEmul e2 (mkAdd (mkProd l2) (PEc C1)) 
-                     | Some (false, l2) =>   PEmul e2 (mkSub (PEc C1) (mkProd l2))
-                     end 
-|   _ => (PEmul (PEc C1) e)
-    end.
-
-Definition isPC1 := fun x => match x with (PEc c) => (isC1 c) | _ => false end.
-Definition isPC0 := fun x => match x with (PEc c) => (isC0 c) | _ => false end.
-
-Fixpoint factor (e:  PExpr C) : PExpr C :=
-  let e1 := match e with
-     PEmul e1 e2  => PEmul (factor e1) (factor e2)
-|     PEadd e1 e2  => PEadd (factor e1) (factor e2)
-|     PEsub e1 e2  => PEsub (factor e1) (factor e2)
-|     PEopp e1        =>  PEopp (factor e1)  
-| _ => e end in
-     let e2 := get_delta e1 in
-                                   if (isPC1 (mkProd e2)) then
-                                     find_trivial_factor e1 (split_factors e1)
-                                   else
-                                     (PEmul (mkProd e2) (subst_factor e2 e1)).
-
-Definition factor_sub := fun f => 
- let e := match f with
-     PEmul e1 e2  => PEmul (factor e1) (factor e2)
-|     PEadd e1 e2  => PEadd (factor e1) (factor e2)
-|     PEsub e1 e2  => PEsub (factor e1) (factor e2)
-|     PEopp e1        =>  PEopp (factor e1)  
-| _ => f end in
-  match e with
-    PEsub e1 e2 =>   
-           if (isPC0 e1)  then
-               let d1 :=  (get_delta e2) in
-                  PEmul (mkProd d1) (PEsub (PEc C0) (subst_factor d1 e2))
-          else if (isPC0 e2) then
-               let d1 := (get_delta e1) in
-                  PEmul (mkProd d1) (PEsub (subst_factor d1 e2) (PEc C0))
-         else
-               let d := get_delta e in
-                  (PEmul (mkProd d) 
-                    (PEsub (subst_factor d e1) 
-                                       (subst_factor d e2)))
-    |  _   => let d := get_delta e in
-                  (PEmul (mkProd d) (subst_factor d e))
+  | l1::ll2 =>
+    let e1 := mkProd l1 in
+    let e2 :=
+        simpl C Cplus Cmul Cop C0 C1 isC1 isC0 isPos Cdivide Cdiv (mkSub e e1)
+    in
+    match subst_elem e2 l1 with
+    | None => find_trivial_factor e ll2
+    | Some (true, l2) => PEmul e2 (mkAdd (mkProd l2) (PEc C1))
+    | Some (false, l2) => PEmul e2 (mkSub (PEc C1) (mkProd l2))
+    end
+  | _ => PEmul (PEc C1) e
   end.
 
-Definition factor_sub_val := fun e d1 => 
+Definition isPC1 x := match x with (PEc c) => (isC1 c) | _ => false end.
+Definition isPC0 x := match x with (PEc c) => (isC0 c) | _ => false end.
+
+Fixpoint factor (e: PExpr C) : PExpr C :=
+  let e1 :=
+      match e with
+      | PEmul e1 e2 => PEmul (factor e1) (factor e2)
+      | PEadd e1 e2 => PEadd (factor e1) (factor e2)
+      | PEsub e1 e2 => PEsub (factor e1) (factor e2)
+      | PEopp e1 => PEopp (factor e1)
+      | _ => e end
+  in
+  let e2 := get_delta e1 in
+  if (isPC1 (mkProd e2)) then
+    find_trivial_factor e1 (split_factors e1)
+  else
+    PEmul (mkProd e2) (subst_factor e2 e1).
+
+Definition factor_sub f :=
+  let e :=
+      match f with
+      | PEmul e1 e2 => PEmul (factor e1) (factor e2)
+      | PEadd e1 e2 => PEadd (factor e1) (factor e2)
+      | PEsub e1 e2 => PEsub (factor e1) (factor e2)
+      | PEopp e1 => PEopp (factor e1)
+      | _ => f end
+  in
+  match e with
+  | PEsub e1 e2 =>
+    if (isPC0 e1) then
+      let d1 := (get_delta e2) in
+      PEmul (mkProd d1) (PEsub (PEc C0) (subst_factor d1 e2))
+    else
+      if (isPC0 e2) then
+        let d1 := (get_delta e1) in
+        PEmul (mkProd d1) (PEsub (subst_factor d1 e2) (PEc C0))
+      else
+        let d := get_delta e in
+        PEmul (mkProd d) (PEsub (subst_factor d e1) (subst_factor d e2))
+  | _ =>
+    let d := get_delta e in
+    PEmul (mkProd d) (subst_factor d e)
+  end.
+
+Definition factor_sub_val e d1 :=
   let d2 := split_factor d1 in
   match e with
-    PEsub e1 e2 =>   
-           if (isPC0 e1)  then
-                  PEmul d1 (PEsub (PEc C0) (subst_factor d2 e2))
-          else if (isPC0 e2) then
-                  PEmul d1 (PEsub (subst_factor d2 e2) (PEc C0))
-         else
-                  (PEmul d1 
-                    (PEsub (subst_factor d2 e1) 
-                                       (subst_factor d2 e2)))
-    |  _   => (PEmul d1 (subst_factor d2 e))
+  | PEsub e1 e2 =>
+    if (isPC0 e1) then
+      PEmul d1 (PEsub (PEc C0) (subst_factor d2 e2))
+    else
+      if (isPC0 e2) then
+        PEmul d1 (PEsub (subst_factor d2 e2) (PEc C0))
+      else
+        PEmul d1 (PEsub (subst_factor d2 e1) (subst_factor d2 e2))
+  | _ => (PEmul d1 (subst_factor d2 e))
   end.
-
 
 End PolFactorSimpl.

--- a/PolRBase.v
+++ b/PolRBase.v
@@ -1,154 +1,160 @@
 Require Import Arith.
 Require Import PolSBase.
 
-
 Section PolReplaceBase.
 
 (* The set of the coefficient usually Z or better Q *)
 Variable C : Set.
 
 (* Usual operations *)
-Variable Cplus : C -> C ->  C.
-Variable Cmul : C -> C ->  C.
-Variable Cop : C ->  C.
+Variable Cplus : C -> C -> C.
+Variable Cmul : C -> C -> C.
+Variable Cop : C -> C.
 
 (* Constant *)
 Variable C0 : C.
 Variable C1 : C.
 
 (* Test to 1 *)
-Variable isC1 : C ->  bool.
+Variable isC1 : C -> bool.
 
 (* Test to 0 *)
-Variable isC0 : C ->  bool.
+Variable isC0 : C -> bool.
 
 (* Test if positive *)
-Variable isPos : C ->  bool.
+Variable isPos : C -> bool.
 
 (* Divisibility *)
-Variable Cdivide : C -> C ->  bool.
+Variable Cdivide : C -> C -> bool.
 
 (* Division *)
-Variable Cdiv : C -> C ->  C.
+Variable Cdiv : C -> C -> C.
 
 
 Let mkMul := mkPEmul C Cmul Cop C0 isC1 isC0.
-Let mkOpp := mkPEopp  C Cop.
+Let mkOpp := mkPEopp C Cop.
 Let mkAdd := mkPEadd C Cplus Cmul Cop C0 isC1 isC0 isPos.
 Let mkSub := mkPEsub C Cplus Cmul Cop C0 isC1 isC0 isPos.
 Let mkAdd0 e1 e2 := if isP0 _ isC0 e1 then e2 else PEadd e1 e2.
-Let mkSub0 e1 e2 := if isP0 _ isC0 e1 then (PEopp e2) else PEsub e1 e2.
+Let mkSub0 e1 e2 := if isP0 _ isC0 e1 then PEopp e2 else PEsub e1 e2.
 
 (* Test if the difference of two terms is zero *)
-Definition is_replace_eq :=  fun x y => 
-  let r :=  simpl_minus C Cplus Cmul Cop C0 C1 isC1 isC0 isPos Cdivide Cdiv (PEsub y x) in
-   match r with
-     PEsub (PEc c) r1  => if (isC0 c) then true else false
-  |  _          => false
+Definition is_replace_eq (x y : PExpr C) : bool :=
+  let r :=
+      simpl_minus C Cplus Cmul Cop C0 C1 isC1 isC0 isPos Cdivide Cdiv (PEsub y x)
+  in
+  match r with
+  | PEsub (PEc c) r1 => if isC0 c then true else false
+  | _ => false
   end.
 
 
-Definition replace_eq :=  fun x y z => 
-  let r :=  simpl_minus C Cplus Cmul Cop C0 C1 isC1 isC0 isPos Cdivide Cdiv (PEsub y x) in
-   match r with
-     PEsub (PEc c) r1  => if (isC0 c) then (Some (mkAdd0 r1 z)) else None
-  |  _          => None
+Definition replace_eq (x y z : PExpr C) : option (PExpr C) :=
+  let r :=
+      simpl_minus C Cplus Cmul Cop C0 C1 isC1 isC0 isPos Cdivide Cdiv (PEsub y x)
+  in
+  match r with
+  | PEsub (PEc c) r1 => if isC0 c then Some (mkAdd0 r1 z) else None
+  | _ => None
   end.
 
 (* Test if the sum of two term is zero *)
 
-Definition is_replace_op :=  fun x y => 
-  let r :=  simpl_minus C Cplus Cmul Cop C0 C1 isC1 isC0 isPos Cdivide Cdiv (PEsub (PEopp y) x) in
-   match r with
-     PEsub (PEc c) r1  => if (isC0 c) then true else false
-  |  _          => false
+Definition is_replace_op (x y : PExpr C) : bool :=
+  let r :=
+      simpl_minus
+        C Cplus Cmul Cop C0 C1 isC1 isC0 isPos Cdivide Cdiv (PEsub (PEopp y) x)
+  in
+  match r with
+  | PEsub (PEc c) r1 => if isC0 c then true else false
+  | _ => false
   end.
 
-Definition replace_op :=  fun x y z => 
-  let r :=  simpl_minus C Cplus Cmul Cop C0 C1 isC1 isC0 isPos Cdivide Cdiv (PEsub (PEopp y) x) in
-   match r with
-     PEsub (PEc c) r1  => if (isC0 c) then (Some (mkSub0 r1 z)) else None
-  |  _          => None
+Definition replace_op (x y z : PExpr C) : option (PExpr C) :=
+  let r :=
+      simpl_minus
+        C Cplus Cmul Cop C0 C1 isC1 isC0 isPos Cdivide Cdiv (PEsub (PEopp y) x)
+  in
+  match r with
+  | PEsub (PEc c) r1 => if isC0 c then Some (mkSub0 r1 z) else None
+  | _ => None
   end.
 
-Definition is_replace_eq_or_op :=
-   fun x y => 
-         match (is_replace_eq x y) with true => true | _ => is_replace_op x y end.
+Definition is_replace_eq_or_op (x y : PExpr C) : bool :=
+  match is_replace_eq x y with true => true | _ => is_replace_op x y end.
 
-Definition replace_eq_or_op :=
-   fun x y  z=> 
-         match (replace_eq x y z) with Some r => Some r| _ => replace_op x y z end.
+Definition replace_eq_or_op (x y z : PExpr C) : option (PExpr C) :=
+  match replace_eq x y z with Some r => Some r | _ => replace_op x y z end.
 
-Definition bool_nat:= fun x => match x with true => 1%nat | false => 0 %nat end.
- 
+Definition bool_nat (x : bool) : nat := match x with true => 1%nat | false => 0 %nat end.
+
 (* Count the number of possible replacement *)
-Fixpoint bcount_replace  (b: bool) (e from: PExpr C) {struct e}: nat  :=
- let (b1, n) := if b then (b,0) else
-                 if is_replace_eq_or_op  e from then (true, 1) else (true, 0)
-          in
-          n + 
-          match e with
-               PEadd e1 e2  =>  
-                 bcount_replace b1 e1 from + bcount_replace b1 e2 from
-            | PEsub e1 e2  =>  
-                 bcount_replace b1 e1 from + bcount_replace b1 e2 from
-             | PEopp e1        =>
-                bcount_replace b1 e1 from
-            | PEmul e1 e2  =>  
-                 bcount_replace false e1 from + bcount_replace false e2 from
-            | _ => 0
-            end.
+Fixpoint bcount_replace (b : bool) (e from : PExpr C) : nat :=
+  let (b1, n) :=
+      if b then (b, 0) else
+        if is_replace_eq_or_op e from then (true, 1)
+        else (true, 0)
+  in
+  n +
+  match e with
+  | PEadd e1 e2 => bcount_replace b1 e1 from + bcount_replace b1 e2 from
+  | PEsub e1 e2 => bcount_replace b1 e1 from + bcount_replace b1 e2 from
+  | PEopp e1 => bcount_replace b1 e1 from
+  | PEmul e1 e2 => bcount_replace false e1 from + bcount_replace false e2 from
+  | _ => 0
+  end.
 
-Definition count_replace :=  bcount_replace false.
+Definition count_replace := bcount_replace false.
 
-(* Return the replaced term  *)
-Fixpoint replace_aux (b: bool) (l: list bool) (e from to: PExpr C) {struct e}: list bool * PExpr C :=
+(* Return the replaced term *)
+Fixpoint replace_aux (b : bool) (l : list bool) (e from to : PExpr C)
+  : list bool * PExpr C :=
   let v := replace_eq_or_op e from to in
-  let b1 := if b then b else if  v then true else false in
-  let b2 := if b then false else if b1 then (nth 0 l false) else false in
-  let ll := if b then l else if  b1 then tail l else l in
+  let b1 := if b then b else if v then true else false in
+  let b2 := if b then false else if b1 then nth 0 l false else false in
+  let ll := if b then l else if b1 then tail l else l in
   let el := match v with (Some v1) => v1 | None => e end in
-            match e with
-               PEadd e1 e2  =>  
-                 let (l1,e3) := replace_aux b1 ll e1 from to in 
-                 let (l2,e4) := replace_aux b1 l1 e2 from to in
-                   (l2, if b2 then el else PEadd e3 e4)
-            | PEsub e1 e2  =>  
-                let (l1,e3) := replace_aux b1 ll e1 from to in 
-                 let (l2,e4) := replace_aux b1 l1 e2 from to in
-                   (l2, if b2 then el else PEsub e3 e4)
-            | PEopp e1        =>
-               let (l1,e3) := replace_aux b1 ll e1 from to in 
-                   (l1, if b2 then el else PEopp e3)
-            | PEmul e1 e2  =>  
-                let (l1,e3) := replace_aux false ll e1 from to in 
-                 let (l2,e4) := replace_aux false l1 e2 from to in
-                   (l2, if b2 then el else PEmul e3 e4)
-            | _ => (ll, if b2 then el else e)
-            end.
+  match e with
+  | PEadd e1 e2 =>
+    let (l1,e3) := replace_aux b1 ll e1 from to in
+    let (l2,e4) := replace_aux b1 l1 e2 from to in
+    (l2, if b2 then el else PEadd e3 e4)
+  | PEsub e1 e2 =>
+    let (l1,e3) := replace_aux b1 ll e1 from to in
+    let (l2,e4) := replace_aux b1 l1 e2 from to in
+    (l2, if b2 then el else PEsub e3 e4)
+  | PEopp e1 =>
+    let (l1,e3) := replace_aux b1 ll e1 from to in
+    (l1, if b2 then el else PEopp e3)
+  | PEmul e1 e2 =>
+    let (l1,e3) := replace_aux false ll e1 from to in
+    let (l2,e4) := replace_aux false l1 e2 from to in
+    (l2, if b2 then el else PEmul e3 e4)
+  | _ => (ll, if b2 then el else e)
+  end.
 
-Fixpoint make_all_const (b: bool) (n:nat) {struct n}: list bool :=
-match n with 0 => nil | (S n1) => b::make_all_const b n1 end.
+Fixpoint make_all_const (b : bool) (n : nat) : list bool :=
+  match n with 0 => nil | S n1 => b::make_all_const b n1 end.
 
-Fixpoint make_one_true  (n1 n2:nat)  {struct n1}: list bool :=
-match n1, n2 with O, _ => nil 
-   | S n3, O => true::make_all_const false n3  
-   | S n3, S n4 => false::make_one_true n3 n4 
- end.
+Fixpoint make_one_true (n1 n2 : nat): list bool :=
+  match n1, n2 with
+  | O, _ => nil
+  | S n3, O => true::make_all_const false n3
+  | S n3, S n4 => false::make_one_true n3 n4
+  end.
 
-Definition replace (e from to: PExpr C) (n: Z) := 
+Definition replace (e from to : PExpr C) (n : Z) :=
   let c := count_replace e from in
   let l :=
-    match n with
-      Z0 => make_all_const true c
-   | Zpos n1 => make_one_true c  (pred (nat_of_P n1))
-   | Zneg n1 => if (Zlt_bool (Z_of_nat c) n) 
-                          then make_all_const false c 
-                          else make_one_true c (c - (nat_of_P n1))%nat
-    end
-    in
-     snd (replace_aux false l e from to).
-
+      match n with
+      | Z0 => make_all_const true c
+      | Zpos n1 => make_one_true c (pred (nat_of_P n1))
+      | Zneg n1 =>
+        if Zlt_bool (Z_of_nat c) n
+        then make_all_const false c
+        else make_one_true c (c - (nat_of_P n1))%nat
+      end
+  in
+  snd (replace_aux false l e from to).
 
 End PolReplaceBase.
-

--- a/PolSBase.v
+++ b/PolSBase.v
@@ -3,35 +3,35 @@
 Require Export ZArith.
 Require Export List.
 Require Import PolAuxList.
- 
+
 Section PolSimplBase.
 
 (* The set of the coefficient usually Z or better Q *)
 Variable C : Set.
 
 (* Usual operations *)
-Variable Cplus : C -> C ->  C.
-Variable Cmul : C -> C ->  C.
-Variable Cop : C ->  C.
+Variable Cplus : C -> C -> C.
+Variable Cmul : C -> C -> C.
+Variable Cop : C -> C.
 
 (* Constant *)
 Variable C0 : C.
 Variable C1 : C.
 
 (* Test to 1 *)
-Variable isC1 : C ->  bool.
+Variable isC1 : C -> bool.
 
 (* Test to 0 *)
-Variable isC0 : C ->  bool.
+Variable isC0 : C -> bool.
 
 (* Test if positive *)
-Variable isPos : C ->  bool.
+Variable isPos : C -> bool.
 
 (* Divisibility *)
-Variable Cdivide : C -> C ->  bool.
+Variable Cdivide : C -> C -> bool.
 
 (* Division *)
-Variable Cdiv : C -> C ->  C.
+Variable Cdiv : C -> C -> C.
 
 (*********************************************************************)
 (*                                                                   *)
@@ -41,11 +41,11 @@ Variable Cdiv : C -> C ->  C.
 
 
 (*   One positive is smaller than another *)
- 
+
 Definition le_pos p1 p2 := Zle_bool (Zpos p1) (Zpos p2).
 
 (* Two positives are equal *)
- 
+
 Definition eq_pos p1 p2 := Zeq_bool (Zpos p1) (Zpos p2).
 
 
@@ -55,108 +55,109 @@ Definition eq_pos p1 p2 := Zeq_bool (Zpos p1) (Zpos p2).
 (*                      Polynomial Expressions                       *)
 (*                                                                   *)
 (*********************************************************************)
- 
+
 Inductive PExpr : Set :=
-  PEc: C ->  PExpr
- | PEX: positive ->  PExpr
- | PEadd: PExpr -> PExpr ->  PExpr
- | PEsub: PExpr -> PExpr ->  PExpr
- | PEmul: PExpr -> PExpr ->  PExpr
- | PEopp: PExpr ->  PExpr .
+| PEc: C -> PExpr
+| PEX: positive -> PExpr
+| PEadd: PExpr -> PExpr -> PExpr
+| PEsub: PExpr -> PExpr -> PExpr
+| PEmul: PExpr -> PExpr -> PExpr
+| PEopp: PExpr -> PExpr .
 
 (* Check if a constant is 0 *)
- 
+
 Definition isP0 e :=
-   match e with PEc c => isC0 c | _ => false end.
+  match e with PEc c => isC0 c | _ => false end.
 (* Check if a constant is 0 *)
- 
+
 Definition isP1 e :=
-   match e with PEc c => isC1 c | _ => false end.
+  match e with PEc c => isC1 c | _ => false end.
 
 (* Simplification for mul when 1 or 0 *)
 
-Definition mkPEmulc (c: C) (e: PExpr) := 
-  if isC0 c then  PEc C0 else
-  if isC1 c then e else
-  match e with
-     (PEc c1) => PEc (Cmul c c1)
-   | (PEopp e1) =>  PEmul (PEc (Cop c)) e1
-   | (PEmul (PEc c1) e1)  => PEmul (PEc (Cmul c c1)) e1
-   | _ => PEmul (PEc c) e
+Definition mkPEmulc (c: C) (e: PExpr) :=
+  if isC0 c then PEc C0 else
+    if isC1 c then e else
+      match e with
+      | (PEc c1) => PEc (Cmul c c1)
+      | (PEopp e1) => PEmul (PEc (Cop c)) e1
+      | (PEmul (PEc c1) e1) => PEmul (PEc (Cmul c c1)) e1
+      | _ => PEmul (PEc c) e
+      end.
+
+Definition mkPEmul (e1 e2 : PExpr) :=
+  match e1 with
+  | (PEc c1) => mkPEmulc c1 e2
+  | (PEopp e3) =>
+    match e2 with
+    | (PEc c2) => mkPEmulc (Cop c2) e3
+    | (PEmul (PEc c2) e4) => mkPEmulc (Cop c2) (PEmul e3 e4)
+    | (PEopp e4) => PEmul e3 e4
+    | _ => PEopp (PEmul e3 e2)
+    end
+  | (PEmul (PEc c1) e3) =>
+    match e2 with
+    | (PEc c2) => mkPEmulc (Cmul c1 c2) e3
+    | (PEmul (PEc c2) (PEopp e4)) => mkPEmulc (Cmul c1 c2) (PEmul e3 e4)
+    | (PEopp e4) => mkPEmulc (Cop c1) (PEmul e3 e4)
+    | _ => mkPEmulc c1 (PEmul e3 e2)
+    end
+  | _ =>
+    match e2 with
+    | (PEc c2) => mkPEmulc c2 e1
+    | (PEmul (PEc c2) e4) => mkPEmulc c2 (PEmul e1 e4)
+    | (PEopp e4) => PEopp (PEmul e1 e4)
+    | _ => PEmul e1 e2
+    end
   end.
- 
-Definition mkPEmul (e1 e2 : PExpr) := 
-   match e1 with
-     (PEc c1) => mkPEmulc c1 e2
-   | (PEopp e3) => 
-                match e2 with
-                 (PEc c2) => mkPEmulc (Cop c2) e3
-                | (PEmul (PEc c2) e4) => mkPEmulc (Cop c2) (PEmul e3 e4)
-                | (PEopp e4) => PEmul e3 e4
-                |  _ => PEopp (PEmul e3 e2)
-                end
-   | (PEmul (PEc c1) e3)  => 
-                match e2 with
-                 (PEc c2) => mkPEmulc (Cmul c1 c2) e3
-                | (PEmul (PEc c2) (PEopp e4)) => mkPEmulc (Cmul c1 c2)
-                                                    (PEmul e3 e4)
-                | (PEopp e4) => mkPEmulc (Cop c1) (PEmul e3 e4)
-                |  _ => mkPEmulc c1 (PEmul e3 e2)
-                end
-   | _ => 
-                match e2 with
-                 (PEc c2) => mkPEmulc c2 e1
-                | (PEmul (PEc c2) e4) => mkPEmulc c2 (PEmul e1 e4)
-                | (PEopp e4) => PEopp (PEmul e1 e4)
-                | _ => PEmul e1 e2
-                end
-   end.
 
 (* Simplification for add when 0 or when to turn it into a substraction *)
- 
+
 Definition mkPEadd (e1 e2 : PExpr) :=
-   match e1, e2 with
-    (PEc c1), (PEc c2) => (PEc (Cplus c1 c2))
-  | _, _ => 
-   if isP0 e1 then e2
-     else if isP0 e2 then e1
-            else match e2 with
-                   PEmul (PEc c1) e3 =>
-                     if isPos c1 then PEadd e1 e2
-                       else PEsub e1 (mkPEmul (PEc (Cop c1)) e3)
-                  | PEc c1 =>
-                      if isPos c1 then PEadd e1 e2 else PEsub e1 (PEc (Cop c1))
-                  | _ => PEadd e1 e2
-                 end
-end.
+  match e1, e2 with
+  | (PEc c1), (PEc c2) => (PEc (Cplus c1 c2))
+  | _, _ =>
+    if isP0 e1 then e2 else
+      if isP0 e2 then e1 else
+        match e2 with
+        | PEmul (PEc c1) e3 =>
+          if isPos c1 then PEadd e1 e2
+          else PEsub e1 (mkPEmul (PEc (Cop c1)) e3)
+        | PEc c1 =>
+          if isPos c1 then PEadd e1 e2
+          else PEsub e1 (PEc (Cop c1))
+        | _ => PEadd e1 e2
+        end
+  end.
 
 (* Simplification for opp when double opp and when there is a coefficient *)
- 
+
 Definition mkPEopp (e1 : PExpr) :=
-   match e1 with
-     PEopp e2 => e2
-    | PEc c1 => PEc (Cop c1)
-    | PEmul (PEc c1) e2 => PEmul (PEc (Cop c1)) e2
-    | _ => PEopp e1
-   end.
+  match e1 with
+  | PEopp e2 => e2
+  | PEc c1 => PEc (Cop c1)
+  | PEmul (PEc c1) e2 => PEmul (PEc (Cop c1)) e2
+  | _ => PEopp e1
+  end.
 
 (* Simplification for sub when 0 or when to turn it into an addition *)
- 
+
 Definition mkPEsub (e1 e2 : PExpr) :=
   match e1, e2 with
-    (PEc c1), (PEc c2) => (PEc (Cplus c1 (Cop c2)))
-  | _ , _ => 
-   if isP0 e1 then mkPEopp e2
-     else if isP0 e2 then e1
-            else match e2 with
-                   PEmul (PEc c1) e3 =>
-                     if isPos c1 then PEsub e1 e2
-                       else PEadd e1 (mkPEmul (PEc (Cop c1)) e3)
-                  | PEc c1 =>
-                      if isPos c1 then PEsub e1 e2 else PEadd e1 (PEc (Cop c1))
-                  | _ => PEsub e1 e2
-                 end
-end.
+  | (PEc c1), (PEc c2) => (PEc (Cplus c1 (Cop c2)))
+  | _ , _ =>
+    if isP0 e1 then mkPEopp e2 else
+      if isP0 e2 then e1 else
+        match e2 with
+        | PEmul (PEc c1) e3 =>
+          if isPos c1 then PEsub e1 e2
+          else PEadd e1 (mkPEmul (PEc (Cop c1)) e3)
+        | PEc c1 =>
+          if isPos c1 then PEsub e1 e2
+          else PEadd e1 (PEc (Cop c1))
+        | _ => PEsub e1 e2
+        end
+  end.
 
 (*********************************************************************)
 (*                                                                   *)
@@ -167,45 +168,45 @@ end.
 (*********************************************************************)
 
 (* Factorize the constant in a product. Always return a product by a constant*)
- 
+
 Definition lift_make_mul (e1 e2 : PExpr) : PExpr :=
-   match e1 with
-     PEc c1 =>
-       match e2 with
-         PEc c2 => PEc (Cmul c1 c2)
-        | PEmul (PEc c2) e4 => PEmul (PEc (Cmul c1 c2)) e4
-        | _ => PEmul (PEc c1) e2
-       end
-    | PEmul (PEc c1) e3 =>
-        match e2 with
-          PEc c2 => PEmul (PEc (Cmul c1 c2)) e3
-         | PEmul (PEc c2) e4 => PEmul (PEc (Cmul c1 c2)) (PEmul e3 e4)
-         | _ => PEmul (PEc c1) (PEmul e3 e2)
-        end
-    | _ =>
-        match e2 with
-          PEc c2 => PEmul (PEc c2) e1
-         | PEmul (PEc c2) e4 => PEmul (PEc c2) (PEmul e1 e4)
-         | _ => PEmul (PEc C1) (PEmul e1 e2)
-        end
-   end.
+  match e1 with
+  | PEc c1 =>
+    match e2 with
+    | PEc c2 => PEc (Cmul c1 c2)
+    | PEmul (PEc c2) e4 => PEmul (PEc (Cmul c1 c2)) e4
+    | _ => PEmul (PEc c1) e2
+    end
+  | PEmul (PEc c1) e3 =>
+    match e2 with
+    | PEc c2 => PEmul (PEc (Cmul c1 c2)) e3
+    | PEmul (PEc c2) e4 => PEmul (PEc (Cmul c1 c2)) (PEmul e3 e4)
+    | _ => PEmul (PEc c1) (PEmul e3 e2)
+    end
+  | _ =>
+    match e2 with
+    | PEc c2 => PEmul (PEc c2) e1
+    | PEmul (PEc c2) e4 => PEmul (PEc c2) (PEmul e1 e4)
+    | _ => PEmul (PEc C1) (PEmul e1 e2)
+    end
+  end.
 
 (* Multiply an expression by the constant 1 if necessary *)
- 
+
 Definition list_mult_one e :=
-   match e with PEX _ => PEmul (PEc C1) e | _ => e end.
+  match e with PEX _ => PEmul (PEc C1) e | _ => e end.
 (* Put a product by a constant in top of each list of products *)
- 
+
 Fixpoint lift_const (e : PExpr) : PExpr :=
- match e with
-   PEadd e1 e2 =>
-     PEadd (list_mult_one (lift_const e1)) (list_mult_one (lift_const e2))
+  match e with
+  | PEadd e1 e2 =>
+    PEadd (list_mult_one (lift_const e1)) (list_mult_one (lift_const e2))
   | PEsub e1 e2 =>
-      PEsub (list_mult_one (lift_const e1)) (list_mult_one (lift_const e2))
+    PEsub (list_mult_one (lift_const e1)) (list_mult_one (lift_const e2))
   | PEmul e1 e2 => lift_make_mul (lift_const e1) (lift_const e2)
   | PEopp e1 => PEopp (list_mult_one (lift_const e1))
   | _ => list_mult_one e
- end.
+  end.
 
 (*********************************************************************)
 (*                                                                   *)
@@ -214,62 +215,63 @@ Fixpoint lift_const (e : PExpr) : PExpr :=
 (*********************************************************************)
 
 (* Variable of position are encoded by a positive *)
- 
+
 Definition pos := positive.
 
 (* Initial pos *)
- 
+
 Definition init_pos : pos := 1%positive.
 
-(* Generate a new position from an old one  *)
- 
+(* Generate a new position from an old one *)
+
 Definition next_pos (p : pos) : pos := (1 + p)%positive.
 
-(* Monomials for positions are encoded by a list  positive *)
- 
+(* Monomials for positions are encoded by a list positive *)
+
 Definition mon_pos := list pos.
 
-(* Do the product of two monomials of position  *)
- 
+(* Do the product of two monomials of position *)
+
 Definition prod_pos (e1 e2 : mon_pos) : mon_pos := app e1 e2.
 
 (* Check if a variable of position is in a monomial *)
- 
+
 Fixpoint pos_in_mon (p : pos) (l : mon_pos) {struct l} : bool :=
- match l with
-   nil => false
+  match l with
+  | nil => false
   | cons p1 l1 => if eq_pos p p1 then true else pos_in_mon p l1
- end.
+  end.
 
 (* Remove a position from a monomial of positions *)
- 
+
 Fixpoint pos_remove (p : pos) (l : mon_pos) {struct l} : mon_pos :=
- match l with
-   nil => nil
+  match l with
+  | nil => nil
   | cons p1 l1 => if eq_pos p p1 then l1 else cons p1 (pos_remove p l1)
- end.
+  end.
 
 (* Insert a variable in an ordered list of position with no repetition *)
- 
+
 Fixpoint insert_list_pos (p1 : pos) (l : list pos) {struct l} : list pos :=
- match l with
-   nil => cons p1 nil
+  match l with
+  | nil => cons p1 nil
   | cons p2 l1 =>
-      if eq_pos p1 p2 then l
-        else if le_pos p1 p2 then cons p1 l else cons p2 (insert_list_pos p1 l1)
- end.
+    if eq_pos p1 p2 then l else
+      if le_pos p1 p2 then cons p1 l
+      else cons p2 (insert_list_pos p1 l1)
+  end.
 
 (* Append two ordered list of variable of positions with no repetition *)
- 
+
 Definition append_pos (l1 l2 : list pos) : list pos :=
-   fold_left (fun l a => insert_list_pos a l) l1 l2.
+  fold_left (fun l a => insert_list_pos a l) l1 l2.
 (* Check if list of positive intersect *)
- 
+
 Fixpoint list_pos_intersect (l1 l2 : list pos) {struct l2} : bool :=
- match l2 with
-   nil => false
+  match l2 with
+  | nil => false
   | cons p1 l3 => if pos_in_mon p1 l1 then true else list_pos_intersect l1 l3
- end.
+  end.
 
 (*********************************************************************)
 (*                                                                   *)
@@ -281,103 +283,103 @@ Fixpoint list_pos_intersect (l1 l2 : list pos) {struct l2} : bool :=
 
 Definition exp := positive.
 
-(* Monomials for expressions are encoded by a list  positive *)
- 
+(* Monomials for expressions are encoded by a list positive *)
+
 Definition mon_exp := list exp.
 
 (* Check if two monomials of expressions are equal *)
- 
+
 Fixpoint mon_exp_eq (l1 l2 : mon_exp) {struct l1} : bool :=
- match l1, l2 with
-   nil, nil => true
+  match l1, l2 with
+  | nil, nil => true
   | cons p1 l3, cons p2 l4 => if eq_pos p1 p2 then mon_exp_eq l3 l4 else false
   | _, _ => false
- end.
+  end.
 
 (* Insert a variable in a monomial of expression *)
- 
+
 Fixpoint insert_exp (p1 : exp) (l : mon_exp) {struct l} : mon_exp :=
- match l with
-   nil => cons p1 nil
+  match l with
+  | nil => cons p1 nil
   | cons p2 l1 => if le_pos p1 p2 then cons p1 l else cons p2 (insert_exp p1 l1)
- end.
+  end.
 
 (* Do the product of two monomials of expression *)
- 
+
 Definition prod_exp (l1 l2 : mon_exp) : mon_exp :=
-   fold_left (fun l a => insert_exp a l) l1 l2.
+  fold_left (fun l a => insert_exp a l) l1 l2.
 
 (* An environment associates a value to each position *)
- 
+
 Definition env := (list (pos * C))%type.
 
 (* Empty environment *)
- 
+
 Definition empty_env : env := nil.
 
 (* Add an element in an enviroment *)
- 
+
 Definition add_env n c e : env := cons (n, c) e.
 
 (* Check if the variable is bound in an environment
-   Check if a position is bounded in an environment *)
- 
+  Check if a position is bounded in an environment *)
+
 Fixpoint is_bound_env (n : pos) (e : env) {struct e} : bool :=
- match e with
-   nil => false
+  match e with
+  | nil => false
   | cons ((n1, c)) e1 => if eq_pos n n1 then true else is_bound_env n e1
- end.
+  end.
 
 (* The number of times a position is associated to zero in an environment*)
- 
+
 Fixpoint number_of_zero_env (e : env) : Z :=
- match e with
-   nil => 0%Z
+  match e with
+  | nil => 0%Z
   | cons ((n1, c)) e1 =>
-      if isC0 c then (1 + number_of_zero_env e1)%Z else number_of_zero_env e1
- end.
+    if isC0 c then (1 + number_of_zero_env e1)%Z else number_of_zero_env e1
+  end.
 
-(* Get the value of a position in an  enviroment*)
- 
+(* Get the value of a position in an enviroment*)
+
 Fixpoint value_env (n : pos) (e : env) {struct e} : C :=
- match e with
-   nil => C0
+  match e with
+  | nil => C0
   | cons ((n1, c)) e1 => if eq_pos n n1 then c else value_env n e1
- end.
+  end.
 
-(* Update  the value of a position in an  enviroment*)
- 
+(* Update the value of a position in an enviroment*)
+
 Fixpoint update_env (n : pos) (c : C) (e : env) {struct e} : env :=
- match e with
-   nil => cons (n, c) nil
+  match e with
+  | nil => cons (n, c) nil
   | cons ((n1, c1)) e1 =>
-      if eq_pos n n1 then cons (n, c) e1 else cons (n1, c1) (update_env n c e1)
- end.
+    if eq_pos n n1 then cons (n, c) e1 else cons (n1, c1) (update_env n c e1)
+  end.
 
 (* Merge two environments *)
- 
+
 Definition merge_env (e1 e2 : env) : env :=
-   fold_left (fun env x =>
-                 match x with (y, val) => update_env y val env end) e1 e2.
+  fold_left (fun env x =>
+               match x with (y, val) => update_env y val env end) e1 e2.
 
 (* Restrict an environment with respect a list of position *)
- 
+
 Let restrict_env (l : list pos) (e : env) : env :=
-   map (fun x => (x, value_env x e)) l.
+  map (fun x => (x, value_env x e)) l.
 
 (* The number of equal associations between two environments*)
- 
+
 Fixpoint number_of_equality_env (e1 e2 : env) {struct e1} : Z :=
- match e1 with
-   nil => 0%Z
-  | cons ((n1, c)) e3 =>
-(*      if isC0 (Cplus c (Cop (value_env n1 e2))) *)
-      if isC0 c then number_of_equality_env e3 e2
-      else if isC0 (value_env n1 e2) then number_of_equality_env e3 e2
-      else if isPos (Cmul c (value_env n1 e2))
+  match e1 with
+  | nil => 0%Z
+  | cons (n1, c) e3 =>
+    (*   if isC0 (Cplus c (Cop (value_env n1 e2))) *)
+    if isC0 c then number_of_equality_env e3 e2 else
+      if isC0 (value_env n1 e2) then number_of_equality_env e3 e2 else
+        if isPos (Cmul c (value_env n1 e2))
         then (1 + number_of_equality_env e3 e2)%Z
         else number_of_equality_env e3 e2
- end.
+  end.
 
 (*********************************************************************)
 (*                                                                   *)
@@ -385,49 +387,48 @@ Fixpoint number_of_equality_env (e1 e2 : env) {struct e1} : Z :=
 (*                                                                   *)
 (*********************************************************************)
 
-(* Definition of a monomial composed of a position part and an  *)
-(* expression part                                              *)
- 
+(* Definition of a monomial composed of a position part and an *)
+(* expression part *)
+
 Definition mon := ((C * mon_pos) * mon_exp)%type.
 
 (* Get the positions information of a monomial *)
- 
+
 Definition get_pos (m : mon) := fst m.
 
 (* Get the expression information of a monomial *)
- 
+
 Definition get_exp (m : mon) := snd m.
 
 (* Create a monomial with an empty monomial expression *)
- 
+
 Definition make_const_mon n : list mon := cons ((C1, cons n nil), nil) nil.
 
 (* Create a monomial with an empty position *)
- 
+
 Definition make_exp_mon x : list mon := cons ((C1, nil), cons x nil) nil.
 
 (* The opposite of a monomial *)
- 
+
 Definition opp_mon (m : mon) : mon :=
-   match m with
-     ((c, l1), l2) => ((Cop c, l1), l2)
-   end.
+  match m with ((c, l1), l2) => ((Cop c, l1), l2) end.
 
 (* Product of two monomials *)
- 
+
 Definition prod_mon (m1 m2 : mon) : mon :=
-   match m1, m2 with
-     ((c1, l1), l2), ((c2, l3), l4) =>
-       ((Cmul c1 c2, prod_pos l1 l3), prod_exp l2 l4)
-   end.
+  match m1, m2 with
+  | ((c1, l1), l2), ((c2, l3), l4) =>
+    ((Cmul c1 c2, prod_pos l1 l3), prod_exp l2 l4)
+  end.
 
 (* Distribute a monomial inside a list of monomials *)
- 
+
 Definition insert_mon (m : mon) (l : list mon) : list mon := map (prod_mon m) l.
+
 (* Do the product of two list of monomials *)
- 
+
 Definition app_mon (l1 l2 : list mon) : list mon :=
-   flat_map (fun x => insert_mon x l1) l2.
+  flat_map (fun x => insert_mon x l1) l2.
 
 (*********************************************************************)
 (*                                                                   *)
@@ -441,56 +442,57 @@ Definition app_mon (l1 l2 : list mon) : list mon :=
 (*   the list of monomials                                          *)
 (*   an environment that associates variable of positions to their  *)
 (*       initial value  the position counter                        *)
- 
+
 Definition list_res := ((list mon * env) * pos)%type.
 
 (*Get the list of monomials from a result *)
- 
+
 Definition list_get_list (r : list_res) : list mon := fst (fst r).
 
 (* Get the default value of the positions *)
- 
+
 Definition list_get_env (e : list_res) :=
-   match e with ((_, e), _) => e end.
+  match e with ((_, e), _) => e end.
 
 (* Get the number of positions that are generated *)
- 
+
 Definition list_get_pos (e : list_res) : pos :=
-   match e with ((_, _), n) => n end.
+  match e with ((_, _), n) => n end.
 
 (* Create a result *)
- 
+
 Definition make_list_res l e n : list_res := ((l, e), n).
 
 (* Create the list of monomials *)
- 
+
 Fixpoint make_list (p : PExpr) (e : env) (n : pos) {struct p} : list_res :=
- match p with
-   PEc c => make_list_res (make_const_mon n) (add_env n c e) (next_pos n)
+  match p with
+  | PEc c => make_list_res (make_const_mon n) (add_env n c e) (next_pos n)
   | PEX x => make_list_res (make_exp_mon x) e n
   | PEopp p1 =>
-      let r1 := make_list p1 e n in
-        make_list_res
-         (map opp_mon (list_get_list r1)) (list_get_env r1) (list_get_pos r1)
+    let r1 := make_list p1 e n in
+    make_list_res
+      (map opp_mon (list_get_list r1))
+      (list_get_env r1) (list_get_pos r1)
   | PEadd p1 p2 =>
-      let r1 := make_list p1 e n in
-        let r2 := make_list p2 (list_get_env r1) (list_get_pos r1) in
-          make_list_res
-           (app (list_get_list r1) (list_get_list r2)) (list_get_env r2)
-           (list_get_pos r2)
+    let r1 := make_list p1 e n in
+    let r2 := make_list p2 (list_get_env r1) (list_get_pos r1) in
+    make_list_res
+      (app (list_get_list r1) (list_get_list r2))
+      (list_get_env r2) (list_get_pos r2)
   | PEsub p1 p2 =>
-      let r1 := make_list p1 e n in
-        let r2 := make_list p2 (list_get_env r1) (list_get_pos r1) in
-          make_list_res
-           (app (list_get_list r1) (map opp_mon (list_get_list r2)))
-           (list_get_env r2) (list_get_pos r2)
+    let r1 := make_list p1 e n in
+    let r2 := make_list p2 (list_get_env r1) (list_get_pos r1) in
+    make_list_res
+      (app (list_get_list r1) (map opp_mon (list_get_list r2)))
+      (list_get_env r2) (list_get_pos r2)
   | PEmul p1 p2 =>
-      let r1 := make_list p1 e n in
-        let r2 := make_list p2 (list_get_env r1) (list_get_pos r1) in
-          make_list_res
-           (app_mon (list_get_list r1) (list_get_list r2)) (list_get_env r2)
-           (list_get_pos r2)
- end.
+    let r1 := make_list p1 e n in
+    let r2 := make_list p2 (list_get_env r1) (list_get_pos r1) in
+    make_list_res
+      (app_mon (list_get_list r1) (list_get_list r2))
+      (list_get_env r2) (list_get_pos r2)
+  end.
 
 (*********************************************************************)
 (*                                                                   *)
@@ -500,48 +502,49 @@ Fixpoint make_list (p : PExpr) (e : env) (n : pos) {struct p} : list_res :=
 (*********************************************************************)
 
 (* A factor is a constant multiplied by a monomial of position *)
- 
+
 Definition factor := (C * mon_pos)%type.
 
 (* Get the list of positions that appear in a list of factors *)
- 
+
 Definition factor_pos (l : list factor) : list pos :=
-   fold_left (fun l a => append_pos (snd a) l) l nil.
+  fold_left (fun l a => append_pos (snd a) l) l nil.
 
 (* Eval a list of factors *)
- 
+
 Fixpoint eval_factors (e : env) (eq : list factor) {struct eq} : C :=
- match eq with
-   nil => C0
+  match eq with
+  | nil => C0
   | cons ((c, l1)) eq1 =>
-      Cplus
-       (Cmul c (fold_left (fun a b => Cmul a (value_env b e)) l1 C1))
-       (eval_factors e eq1)
- end.
+    Cplus
+      (Cmul c (fold_left (fun a b => Cmul a (value_env b e)) l1 C1))
+      (eval_factors e eq1)
+  end.
 
 (* A group is composed of the monomial expression and it is *)
-(* associated list of factor                                *)
- 
+(* associated list of factor                *)
+
 Definition group := (mon_exp * list factor)%type.
 
 (* Create a group *)
- 
+
 Definition make_group e1 e2 : group := (e1, e2).
 
 (* Add a monomial in a list of groups *)
- 
+
 Fixpoint add_groups (m : mon) (l : list group) {struct l} : list group :=
- match l with
-   nil => cons (make_group (get_exp m) (cons (get_pos m) nil)) nil
+  match l with
+  | nil => cons (make_group (get_exp m) (cons (get_pos m) nil)) nil
   | cons ((e, p)) l1 =>
-      if mon_exp_eq e (get_exp m) then cons (e, cons (get_pos m) p) l1
-        else cons (e, p) (add_groups m l1)
- end.
+    if mon_exp_eq e (get_exp m)
+    then cons (e, cons (get_pos m) p) l1
+    else cons (e, p) (add_groups m l1)
+  end.
 
 (* Convert a list of monomials into a list of groups *)
- 
+
 Definition make_groups (l : list mon) : list group :=
-   fold_left (fun l a => add_groups a l) l nil.
+  fold_left (fun l a => add_groups a l) l nil.
 
 (**********************************************************************)
 (*                                                                    *)
@@ -552,50 +555,49 @@ Definition make_groups (l : list mon) : list group :=
 (**********************************************************************)
 
 (* Define an equation as a constant associated to a list of factors *)
- 
+
 Definition equation := (C * list factor)%type.
 
 (* Create an equation *)
- 
+
 Definition make_equation (c : C) (f : list factor) : equation := (c, f).
 
 (* Get the constant in an equation *)
- 
+
 Definition get_const (f : equation) : C := fst f.
 
 (* Get the factors *)
- 
+
 Definition get_factors (f : equation) : list factor := snd f.
 
-(* A system is composed of a list of associated positions and list of  *)
-(*   equations                                                         *)
- 
+(* A system is composed of a list of associated positions and list of *)
+(*  equations                             *)
+
 Definition system := list (list pos * list equation).
- 
+
 Fixpoint add_equation_to_system_aux
- (l : list pos) (f : list equation) (s : system) {struct s} : system :=
- match s with
-   nil => cons (l,f) nil
+         (l : list pos) (f : list equation) (s : system) {struct s} : system :=
+  match s with
+  | nil => cons (l,f) nil
   | cons ((l1, f1)) s1 =>
-      if list_pos_intersect l l1 
-        then add_equation_to_system_aux 
-               (append_pos l l1) (app f f1) s1
-        else cons (l1, f1) (add_equation_to_system_aux l f s1)
- end.
+    if list_pos_intersect l l1
+    then add_equation_to_system_aux (append_pos l l1) (app f f1) s1
+    else cons (l1, f1) (add_equation_to_system_aux l f s1)
+  end.
 
 Definition add_equation_to_system (l : list pos) (f : equation) (s : system)
-                                 : system :=
+  : system :=
   add_equation_to_system_aux l (cons f nil) s.
 
 (* Create a system *)
- 
+
 Fixpoint make_system (e : env) (l : list group) {struct l} : system :=
- match l with
-   nil => nil
+  match l with
+  | nil => nil
   | cons ((_, f)) l1 =>
-      add_equation_to_system
-       (factor_pos f) (make_equation (eval_factors e f) f) (make_system e l1)
- end.
+    add_equation_to_system
+      (factor_pos f) (make_equation (eval_factors e f) f) (make_system e l1)
+  end.
 
 (************************************************************************)
 (*                                                                      *)
@@ -604,156 +606,166 @@ Fixpoint make_system (e : env) (l : list group) {struct l} : system :=
 (*                                                                      *)
 (************************************************************************)
 
-(* Substitute a position p with a value c  in the equation is l = cumul,*)
-(*   to get a new equation                                              *)
- 
-Fixpoint pos_subst (p : pos) (c : C) (cumul : C) (l : list factor) {struct l} :
- equation :=
- match l with
-   nil => (cumul, nil)
-  | cons ((c1, l1)) l2 =>
-      if pos_in_mon p l1
-        then if isC0 (Cmul c c1) then pos_subst p c cumul l2
-               else match pos_remove p l1 with
-                      nil => pos_subst p c (Cplus cumul (Cop (Cmul c c1))) l2
-                     | cons x y =>
-                         let r1 := pos_subst p c cumul l2 in
-                           (fst r1, cons (Cmul c c1, cons x y) (snd r1))
-                    end else let r1 := pos_subst p c cumul l2 in
-                               (fst r1, cons (c1, l1) (snd r1))
- end.
+(* Substitute a position p with a value c in the equation is l = cumul,*)
+(*  to get a new equation                                              *)
 
- 
+Fixpoint pos_subst (p : pos) (c : C) (cumul : C) (l : list factor) {struct l}
+  : equation :=
+  match l with
+  | nil => (cumul, nil)
+  | cons ((c1, l1)) l2 =>
+    if pos_in_mon p l1 then
+      if isC0 (Cmul c c1) then
+        pos_subst p c cumul l2
+      else
+        match pos_remove p l1 with
+        | nil => pos_subst p c (Cplus cumul (Cop (Cmul c c1))) l2
+        | cons x y =>
+          let r1 := pos_subst p c cumul l2 in
+          (fst r1, cons (Cmul c c1, cons x y) (snd r1))
+        end
+    else
+      let r1 := pos_subst p c cumul l2 in
+      (fst r1, cons (c1, l1) (snd r1))
+  end.
+
+
 Definition update_res := option (equation * option (pos * C)).
 
 (* Update an equation if impossible return None, otherwise the new equation *)
-(*  and a possible propagation                                              *)
- 
+(* and a possible propagation                                               *)
+
 Definition update_equation (p : pos) (c : C) (e : equation) : update_res :=
-   match pos_subst p c (get_const e) (get_factors e) with
-     (c1, nil) => if isC0 c1 then Some ((c1, nil), None) else None
-    | (c1, cons ((c2, cons p1 nil)) nil) =>
-        if Cdivide c2 c1 then Some ((C0, nil), Some (p1, Cdiv c1 c2)) else None
-    | (c1, cons ((c2, l1)) nil) =>
-        if Cdivide c2 c1 then Some ((c1, cons (c2, l1) nil), None) else None
-    | (c1, l1) => Some ((c1, l1), None)
-   end.
+  match pos_subst p c (get_const e) (get_factors e) with
+  | (c1, nil) =>
+    if isC0 c1 then Some ((c1, nil), None) else None
+  | (c1, cons ((c2, cons p1 nil)) nil) =>
+    if Cdivide c2 c1 then Some ((C0, nil), Some (p1, Cdiv c1 c2)) else None
+  | (c1, cons ((c2, l1)) nil) =>
+    if Cdivide c2 c1 then Some ((c1, cons (c2, l1) nil), None) else None
+  | (c1, l1) => Some ((c1, l1), None)
+  end.
 
 (* Result of an update of equations*)
- 
+
 Definition updates_res := option (list equation * list (positive * C)).
- 
+
 Definition list_of_option (e : option (positive * C)) :=
-   match e with None => nil | Some e => cons e nil end.
- 
-Definition ocons := fun (x: equation) y =>
+  match e with None => nil | Some e => cons e nil end.
+
+Definition ocons (x : equation) y :=
   match x with (_, nil) => y | _ => (cons x y) end.
 
-Fixpoint update_equations (p : pos) (c : C) (l : list equation) {struct l} :
- updates_res :=
- match l with
-   nil => Some (nil, nil)
+Fixpoint update_equations (p : pos) (c : C) (l : list equation) : updates_res :=
+  match l with
+  | nil => Some (nil, nil)
   | cons eq l1 =>
-      match update_equation p c eq with
-        None => None
-       | Some ((eq1, v1)) =>
-           match update_equations p c l1 with
-             None => None
-            | Some ((l2, l3)) => Some (ocons eq1 l2, app (list_of_option v1) l3)
-           end
+    match update_equation p c eq with
+    | None => None
+    | Some ((eq1, v1)) =>
+      match update_equations p c l1 with
+      | None => None
+      | Some ((l2, l3)) => Some (ocons eq1 l2, app (list_of_option v1) l3)
       end
- end.
+    end
+  end.
 
-(* Result of the propagation of an update of equations,  *)
-(* we use a natural to get the fixpoint behaviour        *)
- 
+(* Result of the propagation of an update of equations, *)
+(* we use a natural to get the fixpoint behaviour       *)
+
 Definition propagate_res := option (list equation * env).
- 
+
 Fixpoint propagate (n : nat) (p : pos) (c : C) (e : env) (l : list equation)
-                   {struct n} : propagate_res :=
- match update_equations p c l with
-   None => None
+         {struct n} : propagate_res :=
+  match update_equations p c l with
+  | None => None
   | Some ((l1, nil)) => Some (l1, update_env p c e)
   | Some ((l1, l2)) =>
-      match n with
-        0 => None
-       | S n1 =>
-           fold_left
-            (fun res a =>
-                match res with
-                  None => None
-                 | Some ((l1, e1)) => propagate n1 (fst a) (snd a) e1 l1
-                end) l2 (Some (l1, update_env p c e))
-      end
- end.
+    match n with
+    | 0 => None
+    | S n1 =>
+      fold_left
+        (fun res a =>
+           match res with
+           | None => None
+           | Some ((l1, e1)) => propagate n1 (fst a) (snd a) e1 l1
+           end)
+        l2 (Some (l1, update_env p c e))
+    end
+  end.
 
-(* A candidat is a solution to a subsystem with it is associated      *)
+(* A candidat is a solution to a subsystem with it is associated   *)
 (* weight. The weight is used to decide with candidat is the best one *)
- 
+
 Definition candidat := option ((Z * Z) * env).
+
 (* Get the best of two candidats*)
- 
+
 Definition get_best (c1 c2 : candidat) : candidat :=
-   match c1 with
-     None => c2
-    | Some (((i1, j1), _)) =>
-        match c2 with
-          None => c1
-         | Some (((i2, j2), _)) =>
-             if Zeq_bool i1 i2 then if Zle_bool j2 j1 then c1 else c2
-               else if Zle_bool i1 i2 then c2 else c1
-        end
-   end.
+  match c1 with
+  | None => c2
+  | Some (((i1, j1), _)) =>
+    match c2 with
+    | None => c1
+    | Some (((i2, j2), _)) =>
+      if Zeq_bool i1 i2 then if Zle_bool j2 j1 then c1 else c2
+      else if Zle_bool i1 i2 then c2 else c1
+    end
+  end.
 
-(* Check if a better solution is possible  *)
- 
+(* Check if a better solution is possible *)
+
 Definition is_possible (best : candidat) (e : env) (vars : list pos) : bool :=
-   match best with
-     None => true
-    | Some (((i1, j1), _)) => Zeq_bool i1 (number_of_zero_env e + Zlength vars)
-   end.
- 
+  match best with
+  | None => true
+  | Some ((i1, j1), _) => Zeq_bool i1 (number_of_zero_env e + Zlength vars)
+  end.
+
 Definition make_candidat (init_e e : env) : candidat :=
-   Some ((number_of_zero_env e, number_of_equality_env e init_e), e).
+  Some ((number_of_zero_env e, number_of_equality_env e init_e), e).
 
-
-(* Try a find a solution using a backtracking algorithm        *)
+(* Try a find a solution using a backtracking algorithm    *)
 (* that takes the first variable in a list and tries to assign *)
-(* it to 0 or to its initial value or leaves it unassigned     *)
- 
+(* it to 0 or to its initial value or leaves it unassigned   *)
+
 Fixpoint search_best_aux (best : candidat) (n: nat) (init_e e : env) (l : list equation)
-                         (vars : list pos)  {struct vars} : candidat :=
- if is_possible best e vars
-   then match vars with
-          nil => match l with nil => get_best best (make_candidat init_e e)
-                    | _ => best
-                    end
-        | cons x vars1 =>
-             if is_bound_env x e then search_best_aux best n init_e e l vars1
-               else let best1 :=
-                     match propagate n x C0 e l with
-                       None => best
-                      | Some ((l1, e1)) =>
-                          search_best_aux best n init_e e1 l1 vars1
-                     end in
-                      let best2 :=
-                       match propagate n x (value_env x init_e) e l
-                        with
-                         None => best
-                        | Some ((l1, e1)) =>
-                            search_best_aux best1 n init_e e1 l1 vars1
-                       end in
-                        search_best_aux best2 n init_e e l vars1
-        end else best.
- 
+         (vars : list pos) {struct vars} : candidat :=
+  if is_possible best e vars then
+    match vars with
+    | nil =>
+      match l with
+      | nil => get_best best (make_candidat init_e e)
+      | _ => best
+      end
+    | cons x vars1 =>
+      if is_bound_env x e then
+        search_best_aux best n init_e e l vars1
+      else
+        let best1 :=
+            match propagate n x C0 e l with
+            | None => best
+            | Some ((l1, e1)) => search_best_aux best n init_e e1 l1 vars1
+            end
+        in
+        let best2 :=
+            match propagate n x (value_env x init_e) e l with
+            | None => best
+            | Some ((l1, e1)) => search_best_aux best1 n init_e e1 l1 vars1
+            end
+        in
+        search_best_aux best2 n init_e e l vars1
+    end
+  else best.
+
 Definition search_best (init_e : env) (s : system) : env :=
-   flat_map
+  flat_map
     (fun x =>
-        match x with
-          (vars, eqs) =>
-            match search_best_aux None  (S (length vars)) (restrict_env vars init_e) nil eqs vars
-             with None => nil | Some ((_, e)) => e end
-        end) s.
+       match x with
+       | (vars, eqs) =>
+         match search_best_aux
+                 None (S (length vars)) (restrict_env vars init_e) nil eqs vars
+         with None => nil | Some (_, e) => e end
+       end) s.
 
 (**********************************************************************)
 (*                                                                    *)
@@ -762,94 +774,92 @@ Definition search_best (init_e : env) (s : system) : env :=
 (*    to get the new expression                                       *)
 (*                                                                    *)
 (**********************************************************************)
- 
-Fixpoint make_PExpr_aux (p : PExpr) (e : env) (n : pos) {struct p} :
- (PExpr * pos)%type :=
- match p with
-   PEc c => (PEc (value_env n e), next_pos n)
+
+Fixpoint make_PExpr_aux (p : PExpr) (e : env) (n : pos) {struct p}
+  : (PExpr * pos)%type :=
+  match p with
+    PEc c => (PEc (value_env n e), next_pos n)
   | PEX x => (p, n)
-  | PEopp p1 => let (fr1,sr1) := make_PExpr_aux p1 e n in
-                  (mkPEopp fr1, sr1)
+  | PEopp p1 =>
+    let (fr1, sr1) := make_PExpr_aux p1 e n in
+    (mkPEopp fr1, sr1)
   | PEadd p1 p2 =>
-      let (fr1, sr1) := make_PExpr_aux p1 e n in
-        let (fr2, sr2) := make_PExpr_aux p2 e sr1 in
-          (mkPEadd fr1 fr2, sr2)
+    let (fr1, sr1) := make_PExpr_aux p1 e n in
+    let (fr2, sr2) := make_PExpr_aux p2 e sr1 in
+    (mkPEadd fr1 fr2, sr2)
   | PEsub p1 p2 =>
-      let (fr1, sr1) := make_PExpr_aux p1 e n in
-        let (fr2, sr2) := make_PExpr_aux p2 e sr1 in
-          (mkPEsub fr1 fr2, sr2)
+    let (fr1, sr1) := make_PExpr_aux p1 e n in
+    let (fr2, sr2) := make_PExpr_aux p2 e sr1 in
+    (mkPEsub fr1 fr2, sr2)
   | PEmul p1 p2 =>
-      let (fr1, sr1) := make_PExpr_aux p1 e n in
-        let (fr2, sr2) := make_PExpr_aux p2 e sr1 in
-          (mkPEmul fr1 fr2, sr2)
- end.
- 
+    let (fr1, sr1) := make_PExpr_aux p1 e n in
+    let (fr2, sr2) := make_PExpr_aux p2 e sr1 in
+    (mkPEmul fr1 fr2, sr2)
+  end.
+
 Definition make_PExpr (p : PExpr) (e : env) :=
-   fst (make_PExpr_aux p e init_pos).
+  fst (make_PExpr_aux p e init_pos).
 
 (* Ensure that the top minus is preserved *)
- 
+
 Definition make_PExpr_minus (p : PExpr) (e : env) :=
-   fst match p with
-         PEsub p1 p2 =>
-           let r1 := make_PExpr_aux p1 e init_pos in
-             let r2 := make_PExpr_aux p2 e (snd r1) in
-               (PEsub (fst r1) (fst r2), snd r2)
-        | _ => make_PExpr_aux p e init_pos
-       end.
+  fst match p with
+      | PEsub p1 p2 =>
+        let r1 := make_PExpr_aux p1 e init_pos in
+        let r2 := make_PExpr_aux p2 e (snd r1) in
+        (PEsub (fst r1) (fst r2), snd r2)
+      | _ => make_PExpr_aux p e init_pos
+      end.
 
 (*********************************************************************)
 (*                                                                   *)
 (*      Put everything together                                      *)
 (*                                                                   *)
 (*********************************************************************)
- 
+
 Definition simpl (e : PExpr) : PExpr :=
-   let exp := lift_const e in
-     let res := make_list exp empty_env init_pos in
-       make_PExpr
-        exp
-        (search_best
-          (list_get_env res)
-          (make_system (list_get_env res) (make_groups (list_get_list res)))).
+  let exp := lift_const e in
+  let res := make_list exp empty_env init_pos in
+  make_PExpr
+    exp
+    (search_best
+       (list_get_env res)
+       (make_system (list_get_env res) (make_groups (list_get_list res)))).
 
 (* Ensure that the top minus is preserved *)
- 
+
 Definition simpl_minus (e : PExpr) :=
-   let exp := lift_const e in
-     let res := make_list exp empty_env init_pos in
-       make_PExpr_minus
-        exp
-        (search_best
-          (list_get_env res)
-          (make_system (list_get_env res) (make_groups (list_get_list res)))).
+  let exp := lift_const e in
+  let res := make_list exp empty_env init_pos in
+  make_PExpr_minus
+    exp
+    (search_best
+       (list_get_env res)
+       (make_system (list_get_env res) (make_groups (list_get_list res)))).
 
 (*********************************************************************)
 (*                                                                   *)
 (*                          Interfaces                               *)
 (*                                                                   *)
 (*********************************************************************)
- 
-Fixpoint convert_back (F : Set) (f : F) (Fadd Fsub Fmult : F -> F ->  F)
-                      (Fop : F ->  F) (C2F : C ->  F) (l : list F) (e : PExpr)
-                      {struct e} : F :=
- match e with
-   PEc c => C2F c
+
+Fixpoint convert_back (F : Set) (f : F) (Fadd Fsub Fmult : F -> F -> F)
+         (Fop : F -> F) (C2F : C -> F) (l : list F) (e : PExpr) : F :=
+  match e with
+  | PEc c => C2F c
   | PEX x => pos_nth f x l
-  | PEopp e1 => Fop (convert_back F f Fadd Fsub Fmult Fop C2F l e1)
+  | PEopp e1 =>
+    Fop (convert_back F f Fadd Fsub Fmult Fop C2F l e1)
   | PEadd e1 e2 =>
-      Fadd
-       (convert_back F f Fadd Fsub Fmult Fop C2F l e1)
-       (convert_back F f Fadd Fsub Fmult Fop C2F l e2)
+    Fadd (convert_back F f Fadd Fsub Fmult Fop C2F l e1)
+         (convert_back F f Fadd Fsub Fmult Fop C2F l e2)
   | PEsub e1 e2 =>
-      Fsub
-       (convert_back F f Fadd Fsub Fmult Fop C2F l e1)
-       (convert_back F f Fadd Fsub Fmult Fop C2F l e2)
+    Fsub (convert_back F f Fadd Fsub Fmult Fop C2F l e1)
+         (convert_back F f Fadd Fsub Fmult Fop C2F l e2)
   | PEmul e1 e2 =>
-      Fmult
-       (convert_back F f Fadd Fsub Fmult Fop C2F l e1)
-       (convert_back F f Fadd Fsub Fmult Fop C2F l e2)
- end.
+    Fmult (convert_back F f Fadd Fsub Fmult Fop C2F l e1)
+          (convert_back F f Fadd Fsub Fmult Fop C2F l e2)
+  end.
 
 End PolSimplBase.
 
@@ -860,87 +870,100 @@ Arguments PEsub [C].
 Arguments PEmul [C].
 Arguments PEopp [C].
 
-
 (* Code taken from Ring *)
 
-(* Path to handle evar 
+(* Path to handle evar
 Ltac IN a l :=
  match l with
  | (cons a ?l) => constr:true
  | (cons _ ?l) => IN a l
- |  nil => constr:false
+ | nil => constr:false
  end.
-*)
+ *)
 
 Ltac term_eq t1 t2 :=
-  constr:(ltac:(first[constr_eq t1 t2; exact true| exact false])).
+  constr:(ltac:(first[constr_eq t1 t2; exact true | exact false])).
 
 Ltac IN a l :=
- match l with
- | (cons ?b ?l1) => 
+  match l with
+  | (cons ?b ?l1) =>
     let t := term_eq a b in
     match t with
-    true => constr:(true)
+    | true => constr:(true)
     | _ => IN a l1
     end
- |  nil => false
- end.
+  | nil => false
+  end.
 
 Ltac AddFv a l :=
- match (IN a l) with
- | true => constr:(l)
- | _ => constr:(cons a l)
- end.
+  match IN a l with
+  | true => constr:(l)
+  | _ => constr:(cons a l)
+  end.
 
 Ltac Find_at a l :=
- match l with
- | nil  => constr:(xH)
- | (cons ?b ?l) => 
-     let t := term_eq a b in
-     match t with
-     | true =>  constr:(xH)
-     | false => let p := Find_at a l in eval compute in (Pos.succ p)
-     end
- end.
-		      
-Ltac FV Cst add mul sub opp t fv :=
- let rec TFV t fv :=
-  match t with
-  | (add ?t1 ?t2) => 
-    let fv1 := TFV t1 fv in let fv2 := TFV t2 fv1 in constr:(fv2)
-  | (mul ?t1 ?t2) => 
-    let fv1 := TFV t1 fv in let fv2 := TFV t2 fv1 in constr:(fv2)
-  | (sub ?t1 ?t2) => 
-    let fv1 := TFV t1 fv in let fv2 := TFV t2 fv1 in constr:(fv2)
-  | (opp ?t1) => 
-    let fv1 := TFV t1 fv in constr:(fv1)
-  | _ =>  
-    match Cst t with
-    | false => let fv1 := AddFv t fv in constr:(fv1)
-    | _ => constr:(fv)
+  match l with
+  | nil => constr:(xH)
+  | (cons ?b ?l) =>
+    let t := term_eq a b in
+    match t with
+    | true => constr:(xH)
+    | false => let p := Find_at a l in eval compute in (Pos.succ p)
     end
-  end 
- in TFV t fv.
+  end.
 
- Ltac mkPolexpr T Cst add mul sub opp t fv := 
- let rec mkP t :=
- match Cst t with
-    | false => 
-       match t with 
-        | (add ?t1 ?t2) => 
-          let e1 := mkP t1 in
-          let e2 := mkP t2 in constr:(PEadd e1 e2)
-        | (mul ?t1 ?t2) => 
-          let e1 := mkP t1 in
-          let e2 := mkP t2 in constr:(PEmul e1 e2)
-        | (sub ?t1 ?t2) => 
-          let e1 := mkP t1 in
-          let e2 := mkP t2 in constr:(PEsub e1 e2)
-        | (opp ?t1) =>
-          let e1 := mkP t1 in constr:(PEopp e1)
-        | _ => let p := Find_at t fv in constr:(@PEX T p)
+Ltac FV Cst add mul sub opp t fv :=
+  let rec TFV t fv :=
+      match t with
+      | (add ?t1 ?t2) =>
+        let fv1 := TFV t1 fv in
+        let fv2 := TFV t2 fv1 in
+        constr:(fv2)
+      | (mul ?t1 ?t2) =>
+        let fv1 := TFV t1 fv in
+        let fv2 := TFV t2 fv1 in
+        constr:(fv2)
+      | (sub ?t1 ?t2) =>
+        let fv1 := TFV t1 fv in
+        let fv2 := TFV t2 fv1 in
+        constr:(fv2)
+      | (opp ?t1) =>
+        let fv1 := TFV t1 fv in
+        constr:(fv1)
+      | _ =>
+        match Cst t with
+        | false =>
+          let fv1 := AddFv t fv in
+          constr:(fv1)
+        | _ => constr:(fv)
         end
-    | ?c => constr:(PEc c)
-  end
-  in mkP t.
+      end
+  in TFV t fv.
 
+Ltac mkPolexpr T Cst add mul sub opp t fv :=
+  let rec mkP t :=
+      match Cst t with
+      | false =>
+        match t with
+        | (add ?t1 ?t2) =>
+          let e1 := mkP t1 in
+          let e2 := mkP t2 in
+          constr:(PEadd e1 e2)
+        | (mul ?t1 ?t2) =>
+          let e1 := mkP t1 in
+          let e2 := mkP t2 in
+          constr:(PEmul e1 e2)
+        | (sub ?t1 ?t2) =>
+          let e1 := mkP t1 in
+          let e2 := mkP t2 in
+          constr:(PEsub e1 e2)
+        | (opp ?t1) =>
+          let e1 := mkP t1 in
+          constr:(PEopp e1)
+        | _ =>
+          let p := Find_at t fv in
+          constr:(@PEX T p)
+        end
+      | ?c => constr:(PEc c)
+      end
+  in mkP t.

--- a/PolTac.v
+++ b/PolTac.v
@@ -1,62 +1,71 @@
-Require Import RSignTac.
-Require Import NSignTac.
-Require Import NatSignTac.
-Require Import ZSignTac.
-
-Ltac sign_tac :=  nsign_tac || Nsign_tac || zsign_tac || rsign_tac.
-
-Ltac hyp_sign_tac H :=  hyp_nsign_tac H || hyp_Nsign_tac H || hyp_zsign_tac H || hyp_rsign_tac H.
-
-
-Require Import RPolS.
-Require Import ZPolS.
-Require Import NatPolS.
-Require Import NPolS.
 Require Export ArithRing.
 Require Export NArithRing.
 
-Ltac pols :=  npols || Npols || zpols || rpols.
+Require Import NatSignTac.
+Require Import NSignTac.
+Require Import ZSignTac.
+Require Import RSignTac.
 
-Ltac hyp_pols H :=  hyp_npols H || hyp_Npols H || hyp_zpols H || hyp_rpols H.
+Ltac sign_tac :=
+  nsign_tac
+  || Nsign_tac
+  || zsign_tac
+  || rsign_tac.
+
+Ltac hyp_sign_tac H :=
+  hyp_nsign_tac H
+  || hyp_Nsign_tac H
+  || hyp_zsign_tac H
+  || hyp_rsign_tac H.
 
 
-Require Import RPolF.
-Require Import ZPolF.
+Require Import NatPolS.
+Require Import NPolS.
+Require Import ZPolS.
+Require Import RPolS.
+
+Ltac pols := npols || Npols || zpols || rpols.
+
+Ltac hyp_pols H :=
+  hyp_npols H
+  || hyp_Npols H
+  || hyp_zpols H
+  || hyp_rpols H.
+
+
 Require Import NatPolF.
 Require Import NPolF.
-Require Export ArithRing.
+Require Import ZPolF.
+Require Import RPolF.
+
+Ltac polf := npolf || Npolf || zpolf || rpolf.
+
+Ltac hyp_polf H :=
+  hyp_npolf H
+  || hyp_Npolf H
+  || hyp_zpolf H
+  || hyp_rpolf H.
 
 
-Ltac polf :=  npolf || Npolf || zpolf || rpolf.
-
-Ltac hyp_polf H := hyp_npolf H || hyp_Npolf H || hyp_zpolf H || hyp_rpolf H.
-
-
-Require Import RPolR.
-Require Import ZPolR.
 Require Import NatPolR.
 Require Import NPolR.
+Require Import ZPolR.
+Require Import RPolR.
 
+Ltac polr term :=
+  match goal with
+  | [ |- ?G ] =>
+    let u := npol_is_compare G in npolr term
+    || let u := Npol_is_compare G in Npolr term
+    || let u := zpol_is_compare G in zpolr term
+    || let u := rpol_is_compare G in rpolr term
+  end.
 
-Ltac polr term :=  
-match goal with |- ?G => 
- (let u := npol_is_compare G in npolr term)
-||
- (let u := Npol_is_compare G in Npolr term)
-||
-(let u := zpol_is_compare G in zpolr term)
-||
-(let u := rpol_is_compare G in rpolr term)
-end.
-
-
-Ltac polrx term dir1 dir2 occ :=  
-match goal with |- ?G => 
-  (let u := npol_is_compare G in npolrx term dir1 dir2 occ)
-||
-  (let u := Npol_is_compare G in Npolrx term dir1 dir2 occ)
-||
-(let u := zpol_is_compare G in zpolrx term dir1 dir2 occ)
-||
-(let u := rpol_is_compare G in rpolrx term dir1 dir2 occ)
-end.
+Ltac polrx term dir1 dir2 occ :=
+  match goal with
+  | [ |- ?G ] =>
+    let u := npol_is_compare G in npolrx term dir1 dir2 occ
+    || let u := Npol_is_compare G in Npolrx term dir1 dir2 occ
+    || let u := zpol_is_compare G in zpolrx term dir1 dir2 occ
+    || let u := rpol_is_compare G in rpolrx term dir1 dir2 occ
+  end.

--- a/RAux.v
+++ b/RAux.v
@@ -57,7 +57,7 @@ Qed.
 Theorem Rlt_sign_pos_pos x y : 0 < x -> 0 < y -> 0 < x * y.
 Proof. intros; apply Rmult_lt_0_compat; auto with real. Qed.
 
-Theorem Rlt_sign_neg_neg x y : x < 0 -> y < 0  -> 0 < x * y.
+Theorem Rlt_sign_neg_neg x y : x < 0 -> y < 0 -> 0 < x * y.
 Proof.
 intros; replace (x * y) with (-x * -y) by ring.
 now apply Rmult_lt_0_compat; auto with real.
@@ -131,7 +131,7 @@ Qed.
 
 Theorem Rle_sign_neg_neg_rev x y : x < 0 -> 0 <= x * y -> y <= 0.
 Proof.
-case (Rle_or_lt y  0); trivial.
+case (Rle_or_lt y 0); trivial.
 intros; absurd (0 <= x * y); trivial.
 now apply Rlt_not_le;apply Rlt_sign_neg_pos.
 Qed.

--- a/RGroundTac.v
+++ b/RGroundTac.v
@@ -3,58 +3,65 @@ Require Import PolAux.
 
 Ltac RCst0 t :=
   match t with
-   | R0 => constr:(Z0)
-   | R1 => constr:(Zpos xH)
-   | Rplus ?e1 ?e2 =>
-       match (RCst0 e1) with
-      | ?e3 => match (RCst0 e2) with
-              |  ?e4 => constr:(Zplus e3  e4)
-              end
+  | R0 => constr:(Z0)
+  | R1 => constr:(Zpos xH)
+  | Rplus ?e1 ?e2 =>
+    match (RCst0 e1) with
+    | ?e3 =>
+      match (RCst0 e2) with
+      | ?e4 => constr:(Zplus e3 e4)
       end
-   | Rminus ?e1 ?e2 =>
-       match (RCst0 e1) with
-      | ?e3 => match (RCst0 e2) with
-              |  ?e4 => constr:(Zminus e3  e4)
-              end
+    end
+  | Rminus ?e1 ?e2 =>
+    match (RCst0 e1) with
+    | ?e3 =>
+      match (RCst0 e2) with
+      | ?e4 => constr:(Zminus e3 e4)
       end
-   | Rmult ?e1 ?e2 =>
-       match (RCst0 e1) with
-      | ?e3 => match (RCst0 e2) with
-              |  ?e4 => constr:(Zmult e3  e4)
-              end
+    end
+  | Rmult ?e1 ?e2 =>
+    match (RCst0 e1) with
+    | ?e3 =>
+      match (RCst0 e2) with
+      | ?e4 => constr:(Zmult e3 e4)
       end
-   | Ropp ?e1 =>
-       match (RCst0 e1) with
-      | ?e3 => constr:(Z.opp e3)
-      end
-   | IZR ?e1 =>
-       match (ZCst e1) with
-       | ?e3 => e3
-       end
-   | _ => constr:(0%Z)
- end.
+    end
+  | Ropp ?e1 =>
+    match (RCst0 e1) with
+    | ?e3 => constr:(Z.opp e3)
+    end
+  | IZR ?e1 =>
+    match (ZCst e1) with
+    | ?e3 => e3
+    end
+  | _ => constr:(0%Z)
+  end.
 
-Ltac rground_tac := match goal with
-|- (?X1 <= ?X2)%R => 
-       let r1 := RCst0 X1 in
-       let r2 := RCst0 X2 in
-       change (Z2R r1 <= Z2R r2)%R; apply Z2R_le; red; apply refl_equal || intros; discriminate
-| |- (?X1 < ?X2)%R => 
-       let r1 := RCst0 X1 in
-       let r2 := RCst0 X2 in
-       change (Z2R r1 < Z2R r2)%R; apply Z2R_lt; red; apply refl_equal || intros; discriminate
-| |- (?X1 >= ?X2)%R => 
-       let r1 := RCst0 X1 in
-       let r2 := RCst0 X2 in
-       change (Z2R r1 >= Z2R r2)%R; apply Z2R_ge; red; apply refl_equal || intros; discriminate
-| |- (?X1 > ?X2)%R => 
-       let r1 := RCst0 X1 in
-       let r2 := RCst0 X2 in
-       change (Z2R r1 > Z2R r2)%R; apply Z2R_gt; red; apply refl_equal || intros; discriminate
-end.
+Ltac rground_tac :=
+  match goal with
+  | |- (?X1 <= ?X2)%R =>
+    let r1 := RCst0 X1 in
+    let r2 := RCst0 X2 in
+    change (Z2R r1 <= Z2R r2)%R; apply Z2R_le;
+    red; apply refl_equal || intros; discriminate
+  | |- (?X1 < ?X2)%R =>
+    let r1 := RCst0 X1 in
+    let r2 := RCst0 X2 in
+    change (Z2R r1 < Z2R r2)%R; apply Z2R_lt;
+    red; apply refl_equal || intros; discriminate
+  | |- (?X1 >= ?X2)%R =>
+    let r1 := RCst0 X1 in
+    let r2 := RCst0 X2 in
+    change (Z2R r1 >= Z2R r2)%R; apply Z2R_ge;
+    red; apply refl_equal || intros; discriminate
+  | |- (?X1 > ?X2)%R =>
+    let r1 := RCst0 X1 in
+    let r2 := RCst0 X2 in
+    change (Z2R r1 > Z2R r2)%R; apply Z2R_gt;
+    red; apply refl_equal || intros; discriminate
+  end.
 
 Hint Extern 4 (_ <= _)%R => rground_tac: real.
 Hint Extern 4 (_ < _)%R => rground_tac: real.
 Hint Extern 4 (_ >= _)%R => rground_tac: real.
 Hint Extern 4 (_ > _)%R => rground_tac: real.
-

--- a/RPolF.v
+++ b/RPolF.v
@@ -1,4 +1,3 @@
-Require Import ZArith.
 Require Import Reals.
 Require Import RPolS.
 Require Import PolSBase.
@@ -16,53 +15,53 @@ Definition Rfactor_minus :=
 
 
 Ltac Rfactor_term term1 term2 :=
-let term := constr:(Rminus term1 term2) in
-let rfv := FV RCst Rplus Rmult Rminus Ropp term (@nil R) in
-let fv := Trev rfv in
-let expr1 := mkPolexpr Z RCst Rplus Rmult Rminus Ropp term1 fv in
-let expr2 := mkPolexpr Z RCst Rplus Rmult Rminus Ropp term2 fv in
-let re := eval vm_compute in (Rfactor_minus (PEsub expr1 expr2)) in
-let factor := match re with (PEmul ?X1 _) => X1 end in
-let expr3 := match re with (PEmul _ (PEsub ?X1 _)) => X1 end in
-let expr4 := match re with (PEmul _ (PEsub _ ?X1 )) => X1 end in
-let
- re1' :=
-  eval
-     unfold
-      Rconvert_back, convert_back,  pos_nth,  jump,
-         hd,  tl, Z2R, P2R in (Rconvert_back (PEmul factor expr3) fv) in
-let re1'' := eval lazy beta in re1' in
-let
- re2' :=
-  eval
-     unfold
-      Rconvert_back, convert_back,  pos_nth,  jump,
-         hd,  tl, Z2R, P2R in (Rconvert_back (PEmul factor expr4) fv) in
-let re2'' := eval lazy beta in re2' in
-replace2_tac term1 term2 re1'' re2''; [idtac| ring | ring].
+  let term := constr:(Rminus term1 term2) in
+  let rfv := FV RCst Rplus Rmult Rminus Ropp term (@nil R) in
+  let fv := Trev rfv in
+  let expr1 := mkPolexpr Z RCst Rplus Rmult Rminus Ropp term1 fv in
+  let expr2 := mkPolexpr Z RCst Rplus Rmult Rminus Ropp term2 fv in
+  let re := (eval vm_compute in (Rfactor_minus (PEsub expr1 expr2))) in
+  let factor := match re with (PEmul ?X1 _) => X1 end in
+  let expr3 := match re with (PEmul _ (PEsub ?X1 _)) => X1 end in
+  let expr4 := match re with (PEmul _ (PEsub _ ?X1 )) => X1 end in
+  let re1' :=
+      (eval
+         unfold
+         Rconvert_back, convert_back, pos_nth, jump,
+       hd, tl, Z2R, P2R in (Rconvert_back (PEmul factor expr3) fv)) in
+  let re1'' := (eval lazy beta in re1')
+  in
+  let re2' :=
+      (eval
+         unfold
+         Rconvert_back, convert_back, pos_nth, jump,
+       hd, tl, Z2R, P2R in (Rconvert_back (PEmul factor expr4) fv)) in
+  let re2'' := (eval lazy beta in re2')
+  in
+  replace2_tac term1 term2 re1'' re2''; [idtac | ring | ring].
 
 Ltac rpolf :=
-progress (
-(try
-match goal with
-| |- (?X1 = ?X2)%R =>  Rfactor_term X1 X2
-| |- (?X1 <> ?X2)%R =>  Rfactor_term X1 X2
-| |- Rlt ?X1 ?X2 => Rfactor_term X1 X2
-| |- Rgt ?X1 ?X2 =>Rfactor_term X1 X2
-| |- Rle ?X1 ?X2 => Rfactor_term X1 X2
-| |- Rge ?X1 ?X2 =>Rfactor_term X1 X2
-| _ => fail end)); try (rsign_tac); try repeat (rewrite Rmult_1_l || rewrite Rmult_1_r).
-
+  progress
+    (try match goal with
+         | |- (?X1 = ?X2)%R => Rfactor_term X1 X2
+         | |- (?X1 <> ?X2)%R => Rfactor_term X1 X2
+         | |- Rlt ?X1 ?X2 => Rfactor_term X1 X2
+         | |- Rgt ?X1 ?X2 => Rfactor_term X1 X2
+         | |- Rle ?X1 ?X2 => Rfactor_term X1 X2
+         | |- Rge ?X1 ?X2 => Rfactor_term X1 X2
+         | _ => fail end);
+  try rsign_tac; try repeat (rewrite Rmult_1_l || rewrite Rmult_1_r).
 
 Ltac hyp_rpolf H :=
-progress (
-generalize H;
-(try
-match type of H with
-  (?X1 = ?X2)%R =>  Rfactor_term X1 X2
-| (?X1 <> ?X2)%R =>  Rfactor_term X1 X2
-| Rlt ?X1 ?X2 => Rfactor_term X1 X2
-| Rgt ?X1 ?X2 =>Rfactor_term X1 X2
-| Rle ?X1 ?X2 => Rfactor_term X1 X2
-| Rge ?X1 ?X2 =>Rfactor_term X1 X2
-| _ => fail end)); clear H; intros H; try (hyp_rsign_tac H); try repeat rewrite Rmult_1_l in H.
+  progress
+    (generalize H;
+     try match type of H with
+         | (?X1 = ?X2)%R => Rfactor_term X1 X2
+         | (?X1 <> ?X2)%R => Rfactor_term X1 X2
+         | Rlt ?X1 ?X2 => Rfactor_term X1 X2
+         | Rgt ?X1 ?X2 => Rfactor_term X1 X2
+         | Rle ?X1 ?X2 => Rfactor_term X1 X2
+         | Rge ?X1 ?X2 => Rfactor_term X1 X2
+         | _ => fail end);
+  clear H; intros H;
+  try hyp_rsign_tac H; try repeat rewrite Rmult_1_l in H.

--- a/RPolR.v
+++ b/RPolR.v
@@ -10,158 +10,153 @@ Require Import RPolF.
 Definition Rreplace_term_aux :=
   replace Z Zplus Zmult Z.opp 0%Z 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div.
 
-Ltac
-Rreplace_term term from to occ id :=
-let rfv := FV RCst Rplus Rmult Rminus Ropp term (@nil R) in
-let rfv1 := FV RCst Rplus Rmult Rminus Ropp from rfv in
-let rfv2 := FV RCst Rplus Rmult Rminus Ropp to rfv1 in
-let fv := Trev rfv2 in
-let expr := mkPolexpr Z RCst Rplus Rmult Rminus Ropp term fv in
-let expr_from := mkPolexpr Z RCst Rplus Rmult Rminus Ropp from fv in
-let expr_to := mkPolexpr Z RCst Rplus Rmult Rminus Ropp to fv in
-let re := eval vm_compute in (Rreplace_term_aux expr expr_from expr_to occ) in
-let term1 := eval
-     unfold Rconvert_back, convert_back,  pos_nth,  jump,
-         hd,  tl, Z2R, P2R in (Rconvert_back re fv) in
-match id with
-     true => term1
+
+Ltac Rreplace_term term from to occ id :=
+  let rfv := FV RCst Rplus Rmult Rminus Ropp term (@nil R) in
+  let rfv1 := FV RCst Rplus Rmult Rminus Ropp from rfv in
+  let rfv2 := FV RCst Rplus Rmult Rminus Ropp to rfv1 in
+  let fv := Trev rfv2 in
+  let expr := mkPolexpr Z RCst Rplus Rmult Rminus Ropp term fv in
+  let expr_from := mkPolexpr Z RCst Rplus Rmult Rminus Ropp from fv in
+  let expr_to := mkPolexpr Z RCst Rplus Rmult Rminus Ropp to fv in
+  let re := (eval vm_compute in (Rreplace_term_aux expr expr_from expr_to occ)) in
+  let term1 :=
+      (eval
+         unfold
+         Rconvert_back, convert_back, pos_nth, jump,
+       hd, tl, Z2R, P2R in (Rconvert_back re fv))
+  in
+  match id with
+  | true => term1
   | false =>
-     match eqterm term term1 with
-       |false => term1
+    match eqterm term term1 with
+    | false => term1
     end
-end
-.
-
-Ltac rpol_is_compare term :=
-match term with
-| (_ < _)%R => constr:(true)
-| (_ > _)%R => constr:(true)
-| (_ <= _)%R => constr:(true)
-| (_ >= _)%R => constr:(true)
-| (?X = _)%R => match type of X with R => constr:(true) end
-| _ => constr:(false)
-end.
-
-Ltac rpol_get_term dir term :=
-match term with
-|  (?op ?X  ?Y)%R =>
-     match dir with P.L => X | P.R => Y end
-|  (?X = ?Y)%R =>
-     match dir with P.L => X | P.R => Y end
-| _ => fail 1 "Unknown term in pol_get_term"
-end.
-
-Ltac rpol_replace_term term1 term2 dir1 dir2 occ id :=
-  let dir2opp := eval compute in (P.pol_dir_opp dir2) in
-  let t1 := rpol_get_term dir2 term2 in
-  let t2 := match id with true => t1 | false => rpol_get_term dir2opp term2 end in
- match term1 with
-   | (?op ?X ?Y) =>
-     match dir1 with
-       P.L  =>
-             Rreplace_term X t1 t2 occ id
-       | P.R =>
-            Rreplace_term Y t1 t2 occ id
-      end
-  | (?X = ?Y)%R  =>
-     match dir1 with
-       P.L  =>
-             Rreplace_term X t1 t2 occ id
-     | P.R =>
-             Rreplace_term Y  t1 t2 occ id
-      end
   end.
 
+Ltac rpol_is_compare term :=
+  match term with
+  | (_ < _)%R => constr:(true)
+  | (_ > _)%R => constr:(true)
+  | (_ <= _)%R => constr:(true)
+  | (_ >= _)%R => constr:(true)
+  | (?X = _)%R => match type of X with R => constr:(true) end
+  | _ => constr:(false)
+  end.
+
+Ltac rpol_get_term dir term :=
+  match term with
+  | (?op ?X ?Y)%R => match dir with P.L => X | P.R => Y end
+  | (?X = ?Y)%R => match dir with P.L => X | P.R => Y end
+  | _ => fail 1 "Unknown term in pol_get_term"
+  end.
+
+Ltac rpol_replace_term term1 term2 dir1 dir2 occ id :=
+  let dir2opp := (eval compute in (P.pol_dir_opp dir2)) in
+  let t1 := rpol_get_term dir2 term2 in
+  let t2 := match id with true => t1 | false => rpol_get_term dir2opp term2 end in
+  match term1 with
+  | (?op ?X ?Y) =>
+    match dir1 with
+    | P.L => Rreplace_term X t1 t2 occ id
+    | P.R => Rreplace_term Y t1 t2 occ id
+    end
+  | (?X = ?Y)%R =>
+    match dir1 with
+    | P.L => Rreplace_term X t1 t2 occ id
+    | P.R => Rreplace_term Y t1 t2 occ id
+    end
+  end.
 
 Ltac rpol_aux_dir term dir :=
   match term with
-   (_ < _)%R => dir
+  | (_ < _)%R => dir
   | (_ > _)%R => dir
   | (_ <= _)%R => eval compute in (P.pol_dir_opp dir)
-  | (_ >= _)%R  => eval compute in (P.pol_dir_opp dir)
-end.
+  | (_ >= _)%R => eval compute in (P.pol_dir_opp dir)
+  end.
 
 Ltac R_eq_trans_l t:=
-   match goal with
-     |  |- (?X >= ?Y)%R => apply eq_Rge_trans_l with t
-     |  |- (?X > ?Y)%R => apply eq_Rgt_trans_l with t
-     |  |- (?X <= ?Y)%R => apply eq_Rle_trans_l with t
-     |  |- (?X < ?Y)%R => apply eq_Rlt_trans_l with t
-     |  |- ?G  => apply trans_equal with t
-    end.
+  match goal with
+  | |- (?X >= ?Y)%R => apply eq_Rge_trans_l with t
+  | |- (?X > ?Y)%R => apply eq_Rgt_trans_l with t
+  | |- (?X <= ?Y)%R => apply eq_Rle_trans_l with t
+  | |- (?X < ?Y)%R => apply eq_Rlt_trans_l with t
+  | |- ?G => apply trans_equal with t
+  end.
 
 Ltac R_eq_trans_r t:=
-   match goal with
-     |  |- (?X >= ?Y)%R => apply eq_Rge_trans_r with t
-     |  |- (?X > ?Y)%R => apply eq_Rgt_trans_r with t
-     |  |- (?X <= ?Y)%R => apply eq_Rle_trans_r with t
-     |  |- (?X < ?Y)%R => apply eq_Rlt_trans_r with t
-     |  |- ?G  => apply trans_equal_r with t
-    end.
-
+  match goal with
+  | |- (?X >= ?Y)%R => apply eq_Rge_trans_r with t
+  | |- (?X > ?Y)%R => apply eq_Rgt_trans_r with t
+  | |- (?X <= ?Y)%R => apply eq_Rle_trans_r with t
+  | |- (?X < ?Y)%R => apply eq_Rlt_trans_r with t
+  | |- ?G => apply trans_equal_r with t
+  end.
 
 (* Do the replacement *)
 Ltac Rreplace_tac_full term dir1 dir2 occ :=
-match term with
- (?T1 = ?T2)%R =>
-  (* We have here a substitution *)
-  match goal with
-     |-  ?G => let  t := rpol_replace_term G term dir1 dir2 occ false in
-              match dir1 with
-               P.L => R_eq_trans_l t
-              | P.R => R_eq_trans_r t
-              end
-  end
-| _ =>
-   match goal with
-     |- (?X <= ?Y)%R  =>
-            let  t := rpol_replace_term (X <= Y)%R term dir1 dir2 occ false in
-               apply Rle_trans with t
-     |  |- (?X >= ?Y)%R =>
-            let  t := rpol_replace_term (X >= Y)%R term dir1 dir2 occ false in
-               apply Rge_trans with t
-     | |- (?X < ?Y)%R  =>
-           let  t := rpol_replace_term (X < Y)%R term dir1 dir2 occ false in
-           match rpol_aux_dir term dir1 with
-                P.L =>
-                                    (apply Rlt_le_trans with t)
-               |P.R =>
-                                    (apply Rle_lt_trans with t)
-            end
-     | |- (?X > ?Y)%R   =>
-            let  t := rpol_replace_term (X > Y)%R term dir1 dir2 occ false in
-           match rpol_aux_dir term dir1 with
-                P.L =>
-                                    (apply Rgt_ge_trans with t)
-               |P.R =>
-                                    (apply Rge_gt_trans with t)
-            end
-   end
-end.
-
+  match term with
+  | (?T1 = ?T2)%R =>
+    (* We have here a substitution *)
+    match goal with
+    | |- ?G =>
+      let t := rpol_replace_term G term dir1 dir2 occ false in
+      match dir1 with
+      | P.L => R_eq_trans_l t
+      | P.R => R_eq_trans_r t
+      end
+    end
+  | _ =>
+    match goal with
+    | |- (?X <= ?Y)%R =>
+      let t := rpol_replace_term (X <= Y)%R term dir1 dir2 occ false in
+      apply Rle_trans with t
+    | |- (?X >= ?Y)%R =>
+      let t := rpol_replace_term (X >= Y)%R term dir1 dir2 occ false in
+      apply Rge_trans with t
+    | |- (?X < ?Y)%R =>
+      let t := rpol_replace_term (X < Y)%R term dir1 dir2 occ false in
+      match rpol_aux_dir term dir1 with
+      | P.L => apply Rlt_le_trans with t
+      | P.R => apply Rle_lt_trans with t
+      end
+    | |- (?X > ?Y)%R =>
+      let t := rpol_replace_term (X > Y)%R term dir1 dir2 occ false in
+      match rpol_aux_dir term dir1 with
+      | P.L => apply Rgt_ge_trans with t
+      | P.R => apply Rge_gt_trans with t
+      end
+    end
+  end.
 
 (* Make the term appears *)
 Ltac Rreplace_tac_full_id term dir1 dir2 occ :=
   match goal with
-     |-  ?G => let t1 := rpol_replace_term G term dir1 dir2 occ true in
-                match dir1 with
-                  P.L => R_eq_trans_l t1
-               | P.R => R_eq_trans_r t1
-                end; [ring | idtac]
-end.
+  | |- ?G =>
+    let t1 := rpol_replace_term G term dir1 dir2 occ true in
+    match dir1 with
+    | P.L => R_eq_trans_l t1
+    | P.R => R_eq_trans_r t1
+    end; [ring | idtac]
+  end.
 
 Ltac rpolrx term dir1 dir2 occ :=
-match rpol_is_compare term with
-  true => Rreplace_tac_full_id term dir1 dir2 occ; [Rreplace_tac_full term dir1 dir2 occ]
-| false =>
-     let t := type of term in
-     match rpol_is_compare t with  true =>
-       Rreplace_tac_full_id t dir1 dir2 occ; [Rreplace_tac_full t dir1 dir2 occ]
-     end
-end.
+  match rpol_is_compare term with
+  | true =>
+    Rreplace_tac_full_id term dir1 dir2 occ;
+    [Rreplace_tac_full term dir1 dir2 occ]
+  | false =>
+    let t := type of term in
+    match rpol_is_compare t with
+    | true =>
+      Rreplace_tac_full_id t dir1 dir2 occ;
+      [Rreplace_tac_full t dir1 dir2 occ]
+    end
+  end.
 
 Ltac rpolr term :=
-  rpolrx term P.L P.L 1%Z ||
-  rpolrx term P.R P.L 1%Z ||
-  rpolrx term P.L P.R 1%Z ||
-  rpolrx term P.R P.R 1%Z.
+  rpolrx term P.L P.L 1%Z
+  || rpolrx term P.R P.L 1%Z
+  || rpolrx term P.L P.R 1%Z
+  || rpolrx term P.R P.R 1%Z.

--- a/RPolS.v
+++ b/RPolS.v
@@ -4,77 +4,70 @@ Require Import PolAuxList.
 Require Import PolAux.
 
 
-
 Definition Rconvert_back (e : PExpr Z) (l : list R) : R :=
-   convert_back Z R R0 Rplus Rminus Rmult Ropp Z2R l e.
+  convert_back Z R R0 Rplus Rminus Rmult Ropp Z2R l e.
 
 Definition Rsimpl_minus (e : PExpr Z) :=
-    (simpl_minus
-      Z Zplus Zmult Z.opp Z0 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div e).
+  simpl_minus
+    Z Zplus Zmult Z.opp Z0 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div e.
 
 Definition Rsimpl (e : PExpr Z) :=
-    (simpl
-      Z Zplus Zmult Z.opp Z0 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div e).
+  simpl
+    Z Zplus Zmult Z.opp Z0 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div e.
 
-Ltac
-rs term1 term2 :=
-let term := constr:(Rminus term1 term2) in
-let rfv := FV RCst Rplus Rmult Rminus Ropp term (@nil R) in
-let fv := Trev rfv in
-let expr1 := mkPolexpr Z RCst Rplus Rmult Rminus Ropp term1 fv in
-let expr2 := mkPolexpr Z RCst Rplus Rmult Rminus Ropp term2 fv in
-let re := eval vm_compute in (Rsimpl_minus (PEsub expr1 expr2)) in
-let expr3 := match re with (PEsub ?X1 _) => X1 end in
-let expr4 := match re with (PEsub _ ?X1 ) => X1 end in
-let re1 :=  constr:(PEsub expr1 expr3) in
-let
- re1' :=
-  eval
-     unfold
-      Rconvert_back, convert_back,  pos_nth,  jump,
-         hd,  tl, Z2R, P2R in (Rconvert_back (PEadd re1 expr3) fv) in
-let re1'' := eval lazy beta in re1' in
-let
- re2' :=
-  eval
-     unfold
-      Rconvert_back, convert_back,  pos_nth,  jump,
-         hd,  tl, Z2R, P2R in (Rconvert_back (PEadd re1 expr4) fv) in
-let re2'' := eval lazy beta in re2' in
-replace2_tac term1 term2 re1'' re2''; [idtac| ring | ring].
+Ltac rs term1 term2 :=
+  let term := constr:(Rminus term1 term2) in
+  let rfv := FV RCst Rplus Rmult Rminus Ropp term (@nil R) in
+  let fv := Trev rfv in
+  let expr1 := mkPolexpr Z RCst Rplus Rmult Rminus Ropp term1 fv in
+  let expr2 := mkPolexpr Z RCst Rplus Rmult Rminus Ropp term2 fv in
+  let re := (eval vm_compute in (Rsimpl_minus (PEsub expr1 expr2))) in
+  let expr3 := match re with (PEsub ?X1 _) => X1 end in
+  let expr4 := match re with (PEsub _ ?X1) => X1 end in
+  let re1 := constr:(PEsub expr1 expr3) in
+  let re1' :=
+      (eval
+         unfold
+         Rconvert_back, convert_back, pos_nth, jump,
+       hd, tl, Z2R, P2R in (Rconvert_back (PEadd re1 expr3) fv))
+  in
+  let re1'' := (eval lazy beta in re1') in
+  let
+    re2' :=
+    (eval
+       unfold
+       Rconvert_back, convert_back, pos_nth, jump,
+     hd, tl, Z2R, P2R in (Rconvert_back (PEadd re1 expr4) fv))
+  in
+  let re2'' := (eval lazy beta in re2') in
+  replace2_tac term1 term2 re1'' re2''; [idtac| ring | ring].
 
-Ltac
-rpols :=
-match goal with
-| |- (?X1 = ?X2)%R =>
-rs X1 X2; try apply Rplus_eq_compat_l
-| |- (?X1 <> ?X2)%R =>
-rs X1 X2; apply Rplus_neg_compat_l
-| |- Rlt ?X1 ?X2 =>
-rs X1 X2; apply Rplus_lt_compat_l
-| |- Rgt ?X1 ?X2 =>
-rs X1 X2; apply Rplus_gt_compat_l
-| |- Rle ?X1 ?X2 =>
-rs X1 X2; apply Rplus_le_compat_l
-| |- Rge ?X1 ?X2 =>
-rs X1 X2; apply Rplus_ge_compat_l
-| _ => fail end.
+Ltac rpols :=
+  match goal with
+  | |- (?X1 = ?X2)%R => rs X1 X2; try apply Rplus_eq_compat_l
+  | |- (?X1 <> ?X2)%R => rs X1 X2; apply Rplus_neg_compat_l
+  | |- Rlt ?X1 ?X2 => rs X1 X2; apply Rplus_lt_compat_l
+  | |- Rgt ?X1 ?X2 => rs X1 X2; apply Rplus_gt_compat_l
+  | |- Rle ?X1 ?X2 => rs X1 X2; apply Rplus_le_compat_l
+  | |- Rge ?X1 ?X2 => rs X1 X2; apply Rplus_ge_compat_l
+  | _ => fail
+  end.
 
-Ltac
-hyp_rpols H :=
-generalize H;
-let tmp := fresh "tmp" in
-match (type of H) with
-   (?X1 = ?X2)%R =>
-rs X1 X2; intros tmp; generalize (Rplus_eq_reg_l _ _ _ tmp); clear H tmp; intro H
-|  (?X1 <> ?X2)%nat =>
-rs X1 X2; intros tmp; generalize (Rplus_neg_reg_l _ _ _ tmp); clear H tmp; intro H
-|  Rlt ?X1 ?X2 =>
-rs X1 X2; intros tmp; generalize (Rplus_lt_reg_r _ _ _ tmp); clear H tmp; intro H
-|  Rgt ?X1 ?X2 =>
-rs X1 X2; intros tmp; generalize (Rplus_gt_reg_l _ _ _ tmp); clear H tmp; intro H
-|  Rle ?X1 ?X2 =>
-rs X1 X2; intros tmp; generalize (Rplus_le_reg_l _ _ _ tmp); clear H tmp; intro H
-|  Rge ?X1 ?X2 =>
-rs X1 X2; intros tmp; generalize (Rplus_ge_reg_l _ _ _ tmp); clear H tmp; intro H
-| _ => fail end.
+Ltac hyp_rpols H :=
+  generalize H;
+  let tmp := fresh "tmp" in
+  match (type of H) with
+  | (?X1 = ?X2)%R =>
+    rs X1 X2; intros tmp; generalize (Rplus_eq_reg_l _ _ _ tmp); clear H tmp; intro H
+  | (?X1 <> ?X2)%nat =>
+    rs X1 X2; intros tmp; generalize (Rplus_neg_reg_l _ _ _ tmp); clear H tmp; intro H
+  | Rlt ?X1 ?X2 =>
+    rs X1 X2; intros tmp; generalize (Rplus_lt_reg_r _ _ _ tmp); clear H tmp; intro H
+  | Rgt ?X1 ?X2 =>
+    rs X1 X2; intros tmp; generalize (Rplus_gt_reg_l _ _ _ tmp); clear H tmp; intro H
+  | Rle ?X1 ?X2 =>
+    rs X1 X2; intros tmp; generalize (Rplus_le_reg_l _ _ _ tmp); clear H tmp; intro H
+  | Rge ?X1 ?X2 =>
+    rs X1 X2; intros tmp; generalize (Rplus_ge_reg_l _ _ _ tmp); clear H tmp; intro H
+  | _ => fail
+  end.

--- a/RSignTac.v
+++ b/RSignTac.v
@@ -1,5 +1,4 @@
 (* Ugly tacty to resolve sign condition for R *)
-
 Require Import RAux.
 Require Export RGroundTac.
 Require Import List.
@@ -8,371 +7,371 @@ Require Import Replace2.
 
 (* Theorems to simplify the goal 0 ? x * y and x * y ? 0 where ? is < > <= >= *)
 
+Definition Rsign_type := fun (x y : list R) => Prop.
 
-Definition Rsign_type := fun (x y:list R) => Prop.
-
-Definition Rsign_cons : forall x y, (Rsign_type  x y) := fun x y => True.
+Definition Rsign_cons : forall x y, (Rsign_type x y) := fun x y => True.
 
 Ltac Rsign_push term1 term2 := generalize (Rsign_cons term1 term2); intro.
 
 Ltac Rsign_le term :=
   match term with
-    (?X1 * ?X2)%R =>  Rsign_le X1;
-                             match goal with
-                             H1: (Rsign_type ?s1 ?s2) |- _ =>
-                                    Rsign_le X2;
-                                   match goal with
-                                      H2: (Rsign_type ?s3 ?s4) |- _ => clear H1 H2;
-                                              let s5 := eval unfold List.app in (s1++s3) in
-                                              let s6 := eval unfold List.app in (s2++s4) in
-                                               Rsign_push s5 s6
-                                   end
-                              end
-| _ =>  let H1 := fresh "H" in
-    (((assert (H1: (0 <= term)%R); [auto with real; fail | idtac])
-      ||
-     (assert (H1: (term <= 0)%R); [auto with real; fail | idtac])); clear H1;
-         Rsign_push (term::nil) (@nil R)) || Rsign_push (@nil R) (term::nil)
-end.
+  | (?X1 * ?X2)%R =>
+    Rsign_le X1;
+    match goal with
+    | H1: (Rsign_type ?s1 ?s2) |- _ =>
+      Rsign_le X2;
+      match goal with
+      | H2: (Rsign_type ?s3 ?s4) |- _ =>
+        clear H1 H2;
+        let s5 := (eval unfold List.app in (s1++s3)) in
+        let s6 := (eval unfold List.app in (s2++s4)) in
+        Rsign_push s5 s6
+      end
+    end
+  | _ =>
+    let H1 := fresh "H" in
+    ((assert (H1: (0 <= term)%R); [auto with real; fail | idtac])
+     || (assert (H1: (term <= 0)%R); [auto with real; fail | idtac]); clear H1;
+     Rsign_push (term::nil) (@nil R)) || Rsign_push (@nil R) (term::nil)
+  end.
 
 Ltac Rsign_lt term :=
   match term with
-    (?X1 * ?X2)%R =>  Rsign_lt X1;
-                             match goal with
-                             H1: (Rsign_type ?s1 ?s2) |- _ =>
-                                    Rsign_lt X2;
-                                   match goal with
-                                      H2: (Rsign_type ?s3 ?s4) |- _ => clear H1 H2;
-                                              let s5 := eval unfold List.app in (s1++s3) in
-                                              let s6 := eval unfold List.app in (s2++s4) in
-                                               Rsign_push s5 s6
-                                   end
-                              end
-| _ =>  let H1 := fresh "H" in
-    (((assert (H1: (0 < term)%R); [auto with real; fail | idtac])
-      ||
-     (assert (H1: (term < 0)%R); [auto with real; fail | idtac])); clear H1;
-         Rsign_push (term::nil) (@nil R)) || Rsign_push (@nil R) (term::nil)
-end.
+  | (?X1 * ?X2)%R =>
+    Rsign_lt X1;
+    match goal with
+    | H1: (Rsign_type ?s1 ?s2) |- _ =>
+      Rsign_lt X2;
+      match goal with
+      | H2: (Rsign_type ?s3 ?s4) |- _ =>
+        clear H1 H2;
+        let s5 := (eval unfold List.app in (s1++s3)) in
+        let s6 := (eval unfold List.app in (s2++s4)) in
+        Rsign_push s5 s6
+      end
+    end
+  | _ =>
+    let H1 := fresh "H" in
+    ((assert (H1: (0 < term)%R); [auto with real; fail | idtac])
+     || (assert (H1: (term < 0)%R); [auto with real; fail | idtac]); clear H1;
+     Rsign_push (term::nil) (@nil R)) || Rsign_push (@nil R) (term::nil)
+  end.
 
 Ltac Rsign_top0 :=
   match goal with
-  |- (0 <= ?X1)%R => Rsign_le  X1
-| |- (?X1 <= 0)%R => Rsign_le  X1
-| |- (0 < ?X1)%R => Rsign_lt  X1
-| |- (?X1 < 0)%R => Rsign_le  X1
-| |- (0 >= ?X1)%R => Rsign_le  X1
-| |- (?X1 >= 0)%R => Rsign_le  X1
-| |- (0 > ?X1 )%R => Rsign_lt X1
-| |- (?X1 > 0)%R => Rsign_le  X1
+  | |- (0 <= ?X1)%R => Rsign_le X1
+  | |- (?X1 <= 0)%R => Rsign_le X1
+  | |- (0 < ?X1)%R => Rsign_lt X1
+  | |- (?X1 < 0)%R => Rsign_le X1
+  | |- (0 >= ?X1)%R => Rsign_le X1
+  | |- (?X1 >= 0)%R => Rsign_le X1
+  | |- (0 > ?X1)%R => Rsign_lt X1
+  | |- (?X1 > 0)%R => Rsign_le X1
   end.
-
 
 Ltac Rsign_top :=
   match goal with
-| |- (?X1 * _ <= ?X1 * _)%R => Rsign_le  X1
-| |- (?X1 * _ < ?X1 * _)%R => Rsign_le  X1
-| |- (?X1 * _ >= ?X1 * _)%R => Rsign_le  X1
-| |- (?X1 * _ > ?X1 * _)%R => Rsign_le  X1
+  | |- (?X1 * _ <= ?X1 * _)%R => Rsign_le X1
+  | |- (?X1 * _ < ?X1 * _)%R => Rsign_le X1
+  | |- (?X1 * _ >= ?X1 * _)%R => Rsign_le X1
+  | |- (?X1 * _ > ?X1 * _)%R => Rsign_le X1
   end.
-
 
 Ltac Rhyp_sign_top0 H:=
   match type of H with
-   (0 <= ?X1)%R => Rsign_lt  X1
-|  (?X1 <= 0)%R => Rsign_lt  X1
-|  (0 < ?X1)%R => Rsign_lt  X1
-|  (?X1 < 0)%R => Rsign_lt X1
-|  (0 >= ?X1)%R => Rsign_lt  X1
-|  (?X1 >= 0)%R => Rsign_lt  X1
-|  (0 > ?X1 )%R => Rsign_lt X1
-|  (?X1 > 0)%R => Rsign_lt  X1
+  | (0 <= ?X1)%R => Rsign_lt X1
+  | (?X1 <= 0)%R => Rsign_lt X1
+  | (0 < ?X1)%R => Rsign_lt X1
+  | (?X1 < 0)%R => Rsign_lt X1
+  | (0 >= ?X1)%R => Rsign_lt X1
+  | (?X1 >= 0)%R => Rsign_lt X1
+  | (0 > ?X1)%R => Rsign_lt X1
+  | (?X1 > 0)%R => Rsign_lt X1
   end.
-
 
 Ltac Rhyp_sign_top H :=
   match type of H with
-|  (?X1 * _ <= ?X1 * _)%R => Rsign_lt  X1
-|  (?X1 * _ < ?X1 * _)%R => Rsign_lt X1
-|  (?X1 * _ >= ?X1 * _)%R => Rsign_lt  X1
-|  (?X1 * _ > ?X1 * _)%R => Rsign_lt  X1
-|  ?X1 => generalize H
+  | (?X1 * _ <= ?X1 * _)%R => Rsign_lt X1
+  | (?X1 * _ < ?X1 * _)%R => Rsign_lt X1
+  | (?X1 * _ >= ?X1 * _)%R => Rsign_lt X1
+  | (?X1 * _ > ?X1 * _)%R => Rsign_lt X1
+  | ?X1 => generalize H
   end.
 
 Ltac Rsign_get_term g :=
   match g with
-   (0 <= ?X1)%R =>  X1
-|  (?X1 <= 0)%R => X1
-|  (?X1 * _ <= ?X1 * _)%R =>  X1
-|  (0 < ?X1)%R =>  X1
-|  (?X1 < 0)%R => X1
-|  (?X1 * _ < ?X1 * _)%R =>  X1
-|  (0 >= ?X1)%R => X1
-|  (?X1 >= 0)%R => X1
-|  (?X1 * _ >= ?X1 * _)%R =>  X1
-|  (?X1 * _  >= _)%R => X1
-|  (0 > ?X1)%R => X1
-|  (?X1 > 0)%R => X1
-|  (?X1 * _ > ?X1 * _)%R =>  X1
+  | (0 <= ?X1)%R => X1
+  | (?X1 <= 0)%R => X1
+  | (?X1 * _ <= ?X1 * _)%R => X1
+  | (0 < ?X1)%R => X1
+  | (?X1 < 0)%R => X1
+  | (?X1 * _ < ?X1 * _)%R => X1
+  | (0 >= ?X1)%R => X1
+  | (?X1 >= 0)%R => X1
+  | (?X1 * _ >= ?X1 * _)%R => X1
+  | (?X1 * _ >= _)%R => X1
+  | (0 > ?X1)%R => X1
+  | (?X1 > 0)%R => X1
+  | (?X1 * _ > ?X1 * _)%R => X1
   end.
 
 Ltac Rsign_get_left g :=
   match g with
-|  (_ * ?X1 <=  _)%R =>  X1
-|  (_ * ?X1 <  _)%R =>  X1
-|  (_ * ?X1 >=  _)%R =>  X1
-|  (_ * ?X1 >  _)%R =>  X1
-end.
+  | (_ * ?X1 <= _)%R => X1
+  | (_ * ?X1 < _)%R => X1
+  | (_ * ?X1 >= _)%R => X1
+  | (_ * ?X1 > _)%R => X1
+  end.
 
 Ltac Rsign_get_right g :=
   match g with
-|  (_ <= _ * ?X1)%R =>  X1
-|  (_ < _ * ?X1)%R =>  X1
-|  (_ >= _ * ?X1)%R =>  X1
-|  (_ > _ * ?X1)%R =>  X1
-end.
+  | (_ <= _ * ?X1)%R => X1
+  | (_ < _ * ?X1)%R => X1
+  | (_ >= _ * ?X1)%R => X1
+  | (_ > _ * ?X1)%R => X1
+  end.
 
 Fixpoint mkRprodt (l: list R)(t:R) {struct l}: R :=
-match l with nil => t | e::l1 => (e * mkRprodt l1 t)%R end.
+  match l with nil => t | e::l1 => (e * mkRprodt l1 t)%R end.
 
 Fixpoint mkRprod (l: list R) : R :=
-match l with nil => 1%R  | e::nil => e | e::l1 => (e * mkRprod l1)%R end.
-
+  match l with nil => 1%R | e::nil => e | e::l1 => (e * mkRprod l1)%R end.
 
 (* Tactic for 0 ? x * y where ? is < > <= >= *)
 
 Ltac rsign_tac_aux0 :=
-match goal with
-  |- (0 <= ?X1 * ?X2)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 <= X1)%R); auto with real; apply Rle_sign_pos_pos)
-      ||
-     (assert (H1: (X1 <= 0)%R); auto with real; apply Rle_sign_neg_neg); try rsign_tac_aux0; clear H1)
-| |- (?X1 * ?X2 <= 0)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 <= X1)%R); auto with real; apply Rle_sign_pos_neg)
-      ||
-     (assert (H1: (X1 <= 0)%R); auto with real; apply Rle_sign_neg_pos); try rsign_tac_aux0; clear H1)
-| |- (0 < ?X1 * ?X2)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 < X1)%R); auto with real; apply Rlt_sign_pos_pos)
-      ||
-     (assert (H1: (X1 < 0)%R); auto with real; apply Rlt_sign_neg_neg); try rsign_tac_aux0; clear H1)
-| |- (?X1 * ?X2 < 0)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 < X1)%R); auto with real; apply Rlt_sign_pos_neg)
-      ||
-     (assert (H1: (X1 < 0)%R); auto with real; apply Rlt_sign_neg_pos); try rsign_tac_aux0; clear H1)
- | |- (?X1 * ?X2 >= 0)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 >= X1)%R); auto with real; apply Rge_sign_neg_neg)
-      ||
-     (assert (H1:  (X1 >= 0)%R); auto with real; apply Rge_sign_pos_pos); try rsign_tac_aux0; clear H1)
-| |- (0 >= ?X1 * ?X2)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (X1 >= 0)%R); auto with real; apply Rge_sign_pos_neg)
-      ||
-     (assert (H1: (0 >= X1)%R); auto with real; apply Rge_sign_neg_pos); try rsign_tac_aux0; clear H1)
-| |- (0 > ?X1 * ?X2)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 > X1)%R); auto with real; apply Rgt_sign_neg_pos)
-      ||
-     (assert (H1: (X1 > 0)%R); auto with real; apply Rgt_sign_pos_neg); try rsign_tac_aux0; clear H1)
-| |- (?X1 * ?X2 > 0)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 > X1)%R); auto with real; apply Rgt_sign_neg_neg)
-      ||
-     (assert (H1: (X1 > 0)%R); auto with real; apply Rgt_sign_pos_pos); try rsign_tac_aux0; clear H1)
-|
- _ => auto with real; fail 1 "rsign_tac_aux"
-end.
-
-Ltac rsign_tac0 := Rsign_top0;
   match goal with
-    H1: (Rsign_type ?s1 ?s2) |- ?g => clear H1;
-    let s := eval unfold mkRprod, mkRprodt in
-                  (mkRprodt s1 (mkRprod s2)) in
+  | |- (0 <= ?X1 * ?X2)%R =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 <= X1)%R); auto with real; apply Rle_sign_pos_pos)
+    || (assert (H1: (X1 <= 0)%R); auto with real; apply Rle_sign_neg_neg);
+    try rsign_tac_aux0; clear H1
+  | |- (?X1 * ?X2 <= 0)%R =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 <= X1)%R); auto with real; apply Rle_sign_pos_neg)
+    || (assert (H1: (X1 <= 0)%R); auto with real; apply Rle_sign_neg_pos);
+    try rsign_tac_aux0; clear H1
+  | |- (0 < ?X1 * ?X2)%R =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 < X1)%R); auto with real; apply Rlt_sign_pos_pos)
+    || (assert (H1: (X1 < 0)%R); auto with real; apply Rlt_sign_neg_neg);
+    try rsign_tac_aux0; clear H1
+  | |- (?X1 * ?X2 < 0)%R =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 < X1)%R); auto with real; apply Rlt_sign_pos_neg)
+    || (assert (H1: (X1 < 0)%R); auto with real; apply Rlt_sign_neg_pos);
+    try rsign_tac_aux0; clear H1
+  | |- (?X1 * ?X2 >= 0)%R =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 >= X1)%R); auto with real; apply Rge_sign_neg_neg)
+    || (assert (H1: (X1 >= 0)%R); auto with real; apply Rge_sign_pos_pos);
+    try rsign_tac_aux0; clear H1
+  | |- (0 >= ?X1 * ?X2)%R =>
+    let H1 := fresh "H" in
+    (assert (H1: (X1 >= 0)%R); auto with real; apply Rge_sign_pos_neg)
+    || (assert (H1: (0 >= X1)%R); auto with real; apply Rge_sign_neg_pos);
+    try rsign_tac_aux0; clear H1
+  | |- (0 > ?X1 * ?X2)%R =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 > X1)%R); auto with real; apply Rgt_sign_neg_pos)
+    || (assert (H1: (X1 > 0)%R); auto with real; apply Rgt_sign_pos_neg);
+    try rsign_tac_aux0; clear H1
+  | |- (?X1 * ?X2 > 0)%R =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 > X1)%R); auto with real; apply Rgt_sign_neg_neg)
+    || (assert (H1: (X1 > 0)%R); auto with real; apply Rgt_sign_pos_pos);
+    try rsign_tac_aux0; clear H1
+  | _ => auto with real; fail 1 "rsign_tac_aux"
+  end.
+
+Ltac rsign_tac0 :=
+  Rsign_top0;
+  match goal with
+  | H1: (Rsign_type ?s1 ?s2) |- ?g =>
+    clear H1;
+    let s := (eval unfold mkRprod, mkRprodt in (mkRprodt s1 (mkRprod s2))) in
     let t := Rsign_get_term g in
-         replace t with s; [try rsign_tac_aux0 | try ring]; auto with real
+    replace t with s; [try rsign_tac_aux0 | try ring]; auto with real
   end.
 
 (* tatic for hyp 0 ? x * y where ? is < > <= >= *)
 
 Ltac hyp_rsign_tac_aux0 H :=
-match  type of H  with
-   (0 <= ?X1 * ?X2)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 < X1)%R); auto with real; generalize (Rle_sign_pos_pos_rev  _ _ H1 H)
-      ||
-     (assert (H1: (X1 < 0)%R); auto with real; generalize (Rle_sign_neg_neg_rev  _ _ H1 H)));
+  match type of H with
+  | (0 <= ?X1 * ?X2)%R =>
+    let H1 := fresh "H" in
+    ((assert (H1: (0 < X1)%R); auto with real; generalize (Rle_sign_pos_pos_rev _ _ H1 H))
+     || (assert (H1: (X1 < 0)%R); auto with real; generalize (Rle_sign_neg_neg_rev _ _ H1 H));
      clear H; intros H; try hyp_rsign_tac_aux0 H; clear H1)
-|  (?X1 * ?X2 <= 0)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 < X1)%R); auto with real; generalize (Rle_sign_pos_neg_rev  _ _ H1 H))
-      ||
-     (assert (H1: (X1 <= 0)%R); auto with real; generalize (Rle_sign_neg_pos_rev  _ _ H1 H));
-      clear H; intros H; try hyp_rsign_tac_aux0 H; clear H1)
-|  (0 < ?X1 * ?X2)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 < X1)%R); auto with real; generalize (Rlt_sign_pos_pos_rev _  _ H1 H))
-      ||
-     (assert (H1: (X1 < 0)%R); auto with real; generalize (Rlt_sign_neg_neg_rev _ _ H1 H));
-      clear H; intros H; try hyp_rsign_tac_aux0 H; clear H1)
-|  (?X1 * ?X2 < 0)%R =>
-  let H1 := fresh "H" in
+  | (?X1 * ?X2 <= 0)%R =>
+    let H1 := fresh "H" in
+    ((assert (H1: (0 < X1)%R); auto with real; generalize (Rle_sign_pos_neg_rev _ _ H1 H))
+     || (assert (H1: (X1 <= 0)%R); auto with real; generalize (Rle_sign_neg_pos_rev _ _ H1 H));
+     clear H; intros H; try hyp_rsign_tac_aux0 H; clear H1)
+  | (0 < ?X1 * ?X2)%R =>
+    let H1 := fresh "H" in
+    ((assert (H1: (0 < X1)%R); auto with real; generalize (Rlt_sign_pos_pos_rev _ _ H1 H))
+     || (assert (H1: (X1 < 0)%R); auto with real; generalize (Rlt_sign_neg_neg_rev _ _ H1 H));
+     clear H; intros H; try hyp_rsign_tac_aux0 H; clear H1)
+  | (?X1 * ?X2 < 0)%R =>
+    let H1 := fresh "H" in
     ((assert (H1: (0 < X1)%R); auto with real; generalize (Rlt_sign_pos_neg_rev _ _ H1 H))
-      ||
-     (assert (H1: (X1 < 0)%R); auto with real; generalize (Rlt_sign_neg_pos_rev _ _ H1 H));
+     || (assert (H1: (X1 < 0)%R); auto with real; generalize (Rlt_sign_neg_pos_rev _ _ H1 H));
      clear H; intros H; try hyp_rsign_tac_aux0 H; clear H1)
- |  (?X1 * ?X2 >= 0)%R =>
-  let H1 := fresh "H" in
+  | (?X1 * ?X2 >= 0)%R =>
+    let H1 := fresh "H" in
     ((assert (H1: (0 >X1)%R); auto with real; generalize (Rge_sign_neg_neg_rev _ _ H1 H))
-      ||
-     (assert (H1:  (X1 > 0)%R); auto with real; generalize (Rge_sign_pos_pos _ _ H1 H));
-      clear H; intros H; try hyp_rsign_tac_aux0 H; clear H1)
-|  (0 >= ?X1 * ?X2)%R =>
-  let H1 := fresh "H" in
+     || (assert (H1: (X1 > 0)%R); auto with real; generalize (Rge_sign_pos_pos _ _ H1 H));
+     clear H; intros H; try hyp_rsign_tac_aux0 H; clear H1)
+  | (0 >= ?X1 * ?X2)%R =>
+    let H1 := fresh "H" in
     ((assert (H1: (X1 > 0)%R); auto with real; generalize (Rge_sign_pos_neg _ _ H1 H))
-      ||
-     (assert (H1: (0 > X1)%R); auto with real; generalize (Rge_sign_neg_pos _ _ H1 H));
+     || (assert (H1: (0 > X1)%R); auto with real; generalize (Rge_sign_neg_pos _ _ H1 H));
      clear H; intros H; try hyp_rsign_tac_aux0 H; clear H1)
-|  (0 > ?X1 * ?X2)%R =>
-  let H1 := fresh "H" in
+  | (0 > ?X1 * ?X2)%R =>
+    let H1 := fresh "H" in
     ((assert (H1: (0 > X1)%R); auto with real; generalize (Rgt_sign_neg_pos _ _ H1 H))
-      ||
-     (assert (H1: (X1 > 0)%R); auto with real; generalize (Rgt_sign_pos_neg _ _ H1 H));
+     || (assert (H1: (X1 > 0)%R); auto with real; generalize (Rgt_sign_pos_neg _ _ H1 H));
      clear H; intros H; try hyp_rsign_tac_aux0 H; clear H1)
-|  (?X1 * ?X2 > 0)%R =>
-  let H1 := fresh "H" in
+  | (?X1 * ?X2 > 0)%R =>
+    let H1 := fresh "H" in
     ((assert (H1: (0 > X1)%R); auto with real; generalize (Rgt_sign_neg_neg _ _ H1 H))
-      ||
-     (assert (H1: (X1 > 0)%R); auto with real; generalize (Rgt_sign_pos_pos _ _ H1 H));
+     || (assert (H1: (X1 > 0)%R); auto with real; generalize (Rgt_sign_pos_pos _ _ H1 H));
      clear H; intros H; try hyp_rsign_tac_aux0 H; clear H1)
-|
- _ => auto with real; fail 1 "hyp_rsign_tac_aux0"
-end.
+  | _ => auto with real; fail 1 "hyp_rsign_tac_aux0"
+  end.
 
-Ltac hyp_rsign_tac0 H := Rhyp_sign_top0 H;
+Ltac hyp_rsign_tac0 H :=
+  Rhyp_sign_top0 H;
   match goal with
-    H1: (Rsign_type ?s1 ?s2) |- ?g => clear H1;
-    let s := eval unfold mkRprod, mkRprodt in
-                  (mkRprodt s1 (mkRprod s2)) in
+  | H1: (Rsign_type ?s1 ?s2) |- ?g =>
+    clear H1;
+    let s := (eval unfold mkRprod, mkRprodt in (mkRprodt s1 (mkRprod s2))) in
     let t := Rsign_get_term g in
-         replace t with s in H; [try hyp_rsign_tac_aux0 H | try ring]; auto with real
+    replace t with s in H; [try hyp_rsign_tac_aux0 H | try ring];
+    auto with real
   end.
 
 (* Tactic for goal x1 * x2 ? x1 * x3 where ? is < > <= >= *)
 
 Ltac rsign_tac_aux :=
-match goal with
- | |- (?X1 * ?X2 <= ?X1 * ?X3)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 <= X1)%R); auto with real; apply Rmult_le_compat_l)
-      ||
-     (assert (H1: (X1 <= 0)%R); auto with real; apply Rmult_le_neg_compat_l); try rsign_tac_aux; clear H1)
-| |- (?X1 * ?X2 < ?X1 * ?X3)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 <= X1)%R); auto with real; apply Rmult_lt_compat_l)
-      ||
-     (assert (H1: (X1 <= 0)%R); auto with real; apply Rmult_lt_neg_compat_l); try rsign_tac_aux; clear H1)
- | |- (?X1 * ?X2 >= ?X1 * ?X3)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (X1 >= 0)%R); auto with real; apply Rmult_ge_compat_l)
-      ||
-     (assert (H1:  (0 >= X1)%R); auto with real; apply Rmult_ge_neg_compat_l); try rsign_tac_aux; clear H1)
-| |- (?X1 * ?X2 > ?X1 * ?X3)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 <= X1)%R); auto with real; apply Rmult_lt_compat_l)
-      ||
-     (assert (H1: (X1 <= 0)%R); auto with real; apply Rmult_lt_neg_compat_l); try rsign_tac_aux; clear H1)
-|
- _ => auto with real; fail 1 "Rsign_tac_aux"
-end.
-
-Ltac rsign_tac := rsign_tac0 || (Rsign_top;
   match goal with
-    H1: (Rsign_type ?s1 ?s2) |- ?g => clear H1;
-    let s := eval unfold mkRprod, mkRprodt in
-                  (mkRprodt s1 (mkRprod s2)) in
-    let t := Rsign_get_term g in
-    let l := Rsign_get_left g in
-    let r := Rsign_get_right g in
-    let sl := eval unfold mkRprod, mkRprodt in
-                  (mkRprodt s1 (Rmult (mkRprod s2) l)) in
-    let sr := eval unfold mkRprod, mkRprodt in
-                  (mkRprodt s1 (Rmult (mkRprod s2) r)) in
-         replace2_tac (Rmult t l) (Rmult t r) sl sr; [rsign_tac_aux | ring | ring]
-  end).
+  | |- (?X1 * ?X2 <= ?X1 * ?X3)%R =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 <= X1)%R); auto with real; apply Rmult_le_compat_l)
+    || (assert (H1: (X1 <= 0)%R); auto with real; apply Rmult_le_neg_compat_l);
+    try rsign_tac_aux; clear H1
+  | |- (?X1 * ?X2 < ?X1 * ?X3)%R =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 <= X1)%R); auto with real; apply Rmult_lt_compat_l)
+    || (assert (H1: (X1 <= 0)%R); auto with real; apply Rmult_lt_neg_compat_l);
+    try rsign_tac_aux; clear H1
+  | |- (?X1 * ?X2 >= ?X1 * ?X3)%R =>
+    let H1 := fresh "H" in
+    (assert (H1: (X1 >= 0)%R); auto with real; apply Rmult_ge_compat_l)
+    || (assert (H1: (0 >= X1)%R); auto with real; apply Rmult_ge_neg_compat_l);
+    try rsign_tac_aux; clear H1
+  | |- (?X1 * ?X2 > ?X1 * ?X3)%R =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 <= X1)%R); auto with real; apply Rmult_lt_compat_l)
+    || (assert (H1: (X1 <= 0)%R); auto with real; apply Rmult_lt_neg_compat_l);
+    try rsign_tac_aux; clear H1
+  | _ => auto with real; fail 1 "Rsign_tac_aux"
+  end.
+
+Ltac rsign_tac :=
+  rsign_tac0
+  || (Rsign_top;
+     match goal with
+     | H1: (Rsign_type ?s1 ?s2) |- ?g =>
+       clear H1;
+       let s := (eval unfold mkRprod, mkRprodt in
+                    (mkRprodt s1 (mkRprod s2)))
+       in
+       let t := Rsign_get_term g in
+       let l := Rsign_get_left g in
+       let r := Rsign_get_right g in
+       let sl := (eval unfold mkRprod, mkRprodt in
+                     (mkRprodt s1 (Rmult (mkRprod s2) l)))
+       in
+       let sr := (eval unfold mkRprod, mkRprodt in
+                     (mkRprodt s1 (Rmult (mkRprod s2) r)))
+       in
+       replace2_tac (Rmult t l) (Rmult t r) sl sr; [rsign_tac_aux | ring | ring]
+     end).
 
 (* Tactic for hyp x1 * x2 ? x1 * x3 where ? is < > <= >= *)
 
 Ltac hyp_rsign_tac_aux H :=
-match type of H with
- | (?X1 * ?X2 <= ?X1 * ?X3)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 < X1)%R); auto with real; generalize (Rmult_le_compat_l_rev _ _ _ H1 H))
-      ||
-     (assert (H1: (X1 < 0)%R); auto with real; generalize (Rmult_le_neg_compat_l_rev _ _ _ H1 H));
-     clear H; intros H; try hyp_rsign_tac_aux H; clear H1)
-|  (?X1 * ?X2 < ?X1 * ?X3)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 < X1)%R); auto with real; generalize (Rmult_lt_compat_l_rev _ _ _ H1 H))
-      ||
-     (assert (H1: (X1 < 0)%R); auto with real; generalize (Rmult_lt_neg_compat_l_rev _ _ _ H1 H));
-    clear H; intros H; try hyp_rsign_tac_aux H; clear H1)
- |  (?X1 * ?X2 >= ?X1 * ?X3)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (X1 > 0)%R); auto with real; generalize (Rmult_ge_compat_l_rev _ _ _ H1 H))
-      ||
-     (assert (H1:  (0 > X1)%R); auto with real; generalize (Rmult_ge_neg_compat_l_rev _ _ _ H1 H));
-    clear H; intros H; try hyp_rsign_tac_aux H; clear H1)
-| (?X1 * ?X2 > ?X1 * ?X3)%R =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 < X1)%R); auto with real; generalize (Rmult_gt_compat_l_rev _ _ _ H1 H))
-      ||
-     (assert (H1: (X1 < 0)%R); auto with real; generalize (Rmult_gt_neg_compat_l_rev _ _ _ H1 H));
-     clear H; intros H; try hyp_rsign_tac_aux H; clear H1)
-|
- _ => auto with real; fail 0 "Rhyp_sign_tac_aux"
-end.
+  match type of H with
+  | (?X1 * ?X2 <= ?X1 * ?X3)%R =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 < X1)%R); auto with real; generalize (Rmult_le_compat_l_rev _ _ _ H1 H))
+    || (assert (H1: (X1 < 0)%R); auto with real; generalize (Rmult_le_neg_compat_l_rev _ _ _ H1 H));
+    clear H; intros H; try hyp_rsign_tac_aux H; clear H1
+  | (?X1 * ?X2 < ?X1 * ?X3)%R =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 < X1)%R); auto with real; generalize (Rmult_lt_compat_l_rev _ _ _ H1 H))
+    || (assert (H1: (X1 < 0)%R); auto with real; generalize (Rmult_lt_neg_compat_l_rev _ _ _ H1 H));
+    clear H; intros H; try hyp_rsign_tac_aux H; clear H1
+  | (?X1 * ?X2 >= ?X1 * ?X3)%R =>
+    let H1 := fresh "H" in
+    (assert (H1: (X1 > 0)%R); auto with real; generalize (Rmult_ge_compat_l_rev _ _ _ H1 H))
+    || (assert (H1: (0 > X1)%R); auto with real; generalize (Rmult_ge_neg_compat_l_rev _ _ _ H1 H));
+    clear H; intros H; try hyp_rsign_tac_aux H; clear H1
+  | (?X1 * ?X2 > ?X1 * ?X3)%R =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 < X1)%R); auto with real; generalize (Rmult_gt_compat_l_rev _ _ _ H1 H))
+    || (assert (H1: (X1 < 0)%R); auto with real; generalize (Rmult_gt_neg_compat_l_rev _ _ _ H1 H));
+    clear H; intros H; try hyp_rsign_tac_aux H; clear H1
+  | _ => auto with real; fail 0 "Rhyp_sign_tac_aux"
+  end.
 
-Ltac hyp_rsign_tac H := hyp_rsign_tac0  H|| (Rhyp_sign_top H;
-  match goal with
-    H1: (Rsign_type ?s1 ?s2) |- _ => clear H1;
-    let s := eval unfold mkRprod, mkRprodt in
-                  (mkRprodt s1 (mkRprod s2)) in
-    let g := type of H in
-    let t := Rsign_get_term g in
-    let l := Rsign_get_left g in
-    let r := Rsign_get_right g in
-    let sl := eval unfold mkRprod, mkRprodt in
-                  (mkRprodt s1 (Rmult (mkRprod s2) l)) in
-    let sr := eval unfold mkRprod, mkRprodt in
-                  (mkRprodt s1 (Rmult (mkRprod s2) r)) in
-         (generalize H; replace2_tac (Rmult t l) (Rmult t r) sl sr; [clear H; intros H; try hyp_rsign_tac_aux H| ring | ring])
-  end).
+Ltac hyp_rsign_tac H :=
+  hyp_rsign_tac0 H
+  || (Rhyp_sign_top H;
+     match goal with
+     | H1: (Rsign_type ?s1 ?s2) |- _ =>
+       clear H1;
+       let s := (eval unfold mkRprod, mkRprodt in
+                    (mkRprodt s1 (mkRprod s2)))
+       in
+       let g := type of H in
+       let t := Rsign_get_term g in
+       let l := Rsign_get_left g in
+       let r := Rsign_get_right g in
+       let sl := (eval unfold mkRprod, mkRprodt in
+                     (mkRprodt s1 (Rmult (mkRprod s2) l)))
+       in
+       let sr := (eval unfold mkRprod, mkRprodt in
+                     (mkRprodt s1 (Rmult (mkRprod s2) r)))
+       in
+       generalize H; replace2_tac (Rmult t l) (Rmult t r) sl sr;
+       [clear H; intros H; try hyp_rsign_tac_aux H | ring | ring]
+     end).
 
 Section Test.
 
-Let test : forall a b c, (0 < a -> a * b < a * c -> b < c)%R.
-intros a b c H1 H.
-hyp_rsign_tac H.
+Let test1 : forall a b c, (0 < a -> a * b < a * c -> b < c)%R.
+Proof.
+intros a b c H1 H2.
+hyp_rsign_tac H2.
 Qed.
 
-
-Let test1 : forall a b c, (a < 0 -> a * b < a * c -> c < b)%R.
-intros a b c H H1.
-hyp_rsign_tac H1.
+Let test2 : forall a b c, (a < 0 -> a * b < a * c -> c < b)%R.
+Proof.
+intros a b c H1 H2.
+hyp_rsign_tac H2.
 Qed.
 
-Let test2 : forall a b c, (0 < a -> a * b <= a * c -> b <= c)%R.
-intros a b c H H1.
-hyp_rsign_tac H1.
+Let test3 : forall a b c, (0 < a -> a * b <= a * c -> b <= c)%R.
+intros a b c H1 H2.
+hyp_rsign_tac H2.
 Qed.
 
-Let test3 : forall a b c, (0 >  a ->  (a * b) >= (a * c) -> c >= b)%R.
-intros a b c H H1.
-hyp_rsign_tac H1.
+Let test4 : forall a b c, (0 > a -> (a * b) >= (a * c) -> c >= b)%R.
+intros a b c H1 H2.
+hyp_rsign_tac H2.
 Qed.
 
 End Test.

--- a/Replace2.v
+++ b/Replace2.v
@@ -1,16 +1,16 @@
-
 (* A simple tactic to do the parallel replacement of the first occurence of term1
-    with term3 and the firs occurrence of term2 with term4 
-*)
+    with term3 and the firs occurrence of term2 with term4
+ *)
 Ltac replace2_tac term1 term2 term3 term4 :=
-let tmp1 := fresh "tmp" in
-let tmp2 := fresh "tmp" in
-let tmp3 := fresh "tmp" in
-let tmp4 := fresh "tmp" in
-  (set (tmp1 := term1) in |- * at 1; 
-   set (tmp2 := term2) in |-* at 1;
-   (set (tmp3 := term1); set (tmp4 := term2));
-   unfold tmp1; clear tmp1; replace term1 with term3;
-   set (tmp1 := term3);
-   unfold tmp2; clear tmp2;
-  [ replace term2 with term4 | idtac]; unfold tmp1, tmp3, tmp4; clear tmp1 tmp3 tmp4). 
+  let tmp1 := fresh "tmp" in
+  let tmp2 := fresh "tmp" in
+  let tmp3 := fresh "tmp" in
+  let tmp4 := fresh "tmp" in
+  set (tmp1 := term1) in |- * at 1;
+  set (tmp2 := term2) in |-* at 1;
+  set (tmp3 := term1); set (tmp4 := term2);
+  unfold tmp1; clear tmp1; replace term1 with term3;
+  set (tmp1 := term3);
+  unfold tmp2; clear tmp2;
+  [ replace term2 with term4 | idtac];
+  unfold tmp1, tmp3, tmp4; clear tmp1 tmp3 tmp4.

--- a/ReplaceTest.v
+++ b/ReplaceTest.v
@@ -1,20 +1,237 @@
 Require Import PolTac.
+Require Import Arith.
+Require Import NArith.
 Require Import ZArith.
+Require Import Reals.
 
-(* Test for Z *)
-Open Scope  Z_scope.
+(* Tests for Nat *)
+Open Scope nat_scope.
+
+Goal forall a b c d, a + c = d -> b = c -> a + b + c = c + d.
+Proof.
+intros.
+polr (a + c = d).
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, 0 = d -> a + b = 0 -> a + b + c = c + d.
+Proof.
+intros.
+polr (d = 0).
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, a + c <= d -> b <= c -> a + b + c <= c + d.
+Proof.
+intros.
+polr (a + c < d).
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, a + b <= 0 -> 0 <= d -> a + b + c <= c + d.
+Proof.
+intros.
+polrx (0 < d) P.R P.R 1%Z.
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, a + c <= d -> b <= c -> a + b + c <= c + d.
+Proof.
+intros.
+polr (a + c < d).
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, a + b >= 0 -> 0 >= d -> a + b + c >= c + d.
+Proof.
+intros.
+polrx (0 < d) P.R P.R 1%Z.
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, a + c < d -> b <= c -> a + b + c < c + d.
+Proof.
+intros.
+polr (a + c < d).
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, a + b <= 0 -> 0 < d -> a + b + c < c + d.
+Proof.
+intros.
+polrx (0 < d) P.R P.R 1%Z.
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, a + c > d -> c <= b -> a + b + c > c + d.
+Proof.
+intros.
+(* NatPolR.npolrx (a + c < d) P.L P.L 1%Z. *)
+polr (a + c < d).
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, 0 <= a + b -> 0 > d -> a + b + c > c + d.
+Proof.
+intros.
+polrx (0 < d) P.R P.R 1%Z.
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Close Scope nat_scope.
+
+
+(* Tests for N *)
+Open Scope N_scope.
+
+Goal forall a b c d, a + c = d -> b = c -> a + b + c = c + d.
+Proof.
+intros.
+polr (a + c = d).
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, 0 = d -> a + b = 0 -> a + b + c = c + d.
+Proof.
+intros.
+polr (d = 0).
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, a + c <= d -> b <= c -> a + b + c <= c + d.
+Proof.
+intros.
+polr (a + c < d).
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, a + b <= 0 -> 0 <= d -> a + b + c <= c + d.
+Proof.
+intros.
+polrx (0 < d) P.R P.R 1%Z.
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, a + c >= d -> b >= c -> a + b + c >= c + d.
+Proof.
+intros.
+polr (a + c < d).
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, a + b >= 0 -> 0 >= d -> a + b + c >= c + d.
+Proof.
+intros.
+polrx (0 < d) P.R P.R 1%Z.
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, a + c < d -> b <= c -> a + b + c < c + d.
+Proof.
+intros.
+polr (a + c < d).
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, a + b <= 0 -> 0 < d -> a + b + c < c + d.
+Proof.
+intros.
+polrx (0 < d) P.R P.R 1%Z.
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, a + c > d -> c <= b -> a + b + c > c + d.
+Proof.
+intros.
+polr (a + c < d).
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Goal forall a b c d, 0 <= a + b -> 0 > d -> a + b + c > c + d.
+Proof.
+intros.
+polrx (0 < d) P.R P.R 1%Z.
+pols.
+auto.
+pols.
+auto.
+Qed.
+
+Close Scope N_scope.
+
+
+(* Tests for Z *)
+Open Scope Z_scope.
 
 Ltac cg g := match goal with |- g => idtac end.
 
-
 Goal forall a b c d, a + c = d -> b + d = c + d -> a + b + c = c + d.
+Proof.
 intros a b c d H1 H2.
 polr H1.
-rewrite H1; auto. 
+rewrite H1; auto.
 auto.
 Qed.
 
 Goal forall a b c d, d = 0 -> a + b + c = c + 0 -> a + b + c = c + d.
+Proof.
 intros a b c d H1 H2.
 polr H1.
 rewrite H1; auto.
@@ -22,6 +239,7 @@ auto.
 Qed.
 
 Goal forall a b c d, a + c <= d -> b <= c -> a + b + c <= c + d.
+Proof.
 intros a b c d H1 H2.
 polr H1.
 pols.
@@ -30,7 +248,8 @@ pols.
 auto.
 Qed.
 
-Goal forall a b c d,  a + b  <= 0 -> 0 <= d -> a + b + c <= c + d.
+Goal forall a b c d, a + b <= 0 -> 0 <= d -> a + b + c <= c + d.
+Proof.
 intros.
 polrx (0 < d) P.R P.R 1%Z.
 pols.
@@ -40,6 +259,7 @@ auto.
 Qed.
 
 Goal forall a b c d, a + c >= d -> b >= c -> a + b + c >= c + d.
+Proof.
 intros.
 polr (a + c < d).
 pols.
@@ -49,6 +269,7 @@ auto.
 Qed.
 
 Goal forall a b c d, a + b >= 0 -> 0 >= d -> a + b + c >= c + d.
+Proof.
 intros.
 polrx (0 < d) P.R P.R 1%Z.
 pols.
@@ -57,8 +278,8 @@ pols.
 auto.
 Qed.
 
-
 Goal forall a b c d, a + c < d -> b <= c -> a + b + c < c + d.
+Proof.
 intros.
 polr (a + c < d).
 pols.
@@ -68,6 +289,7 @@ auto.
 Qed.
 
 Goal forall a b c d, a + b <= 0 -> 0 < d -> a + b + c < c + d.
+Proof.
 intros.
 polrx (0 < d) P.R P.R 1%Z.
 pols.
@@ -77,6 +299,7 @@ auto.
 Qed.
 
 Goal forall a b c d, a + c > d -> c <= b -> a + b + c > c + d.
+Proof.
 intros.
 polr (a + c < d).
 pols.
@@ -86,6 +309,7 @@ auto.
 Qed.
 
 Goal forall a b c d, 0 <= a + b -> 0 > d -> a + b + c > c + d.
+Proof.
 intros.
 polrx (0 < d) P.R P.R 1%Z.
 pols.
@@ -94,11 +318,14 @@ pols.
 auto.
 Qed.
 
-(* Test for N *)
-Require Import NAux.
-Open Scope  N_scope.
+Close Scope Z_scope.
+
+
+(* Tests for R *)
+Open Scope R_scope.
 
 Goal forall a b c d, a + c = d -> b = c -> a + b + c = c + d.
+Proof.
 intros.
 polr (a + c = d).
 pols.
@@ -108,6 +335,7 @@ auto.
 Qed.
 
 Goal forall a b c d, 0 = d -> a + b = 0 -> a + b + c = c + d.
+Proof.
 intros.
 polr (d = 0).
 pols.
@@ -117,6 +345,7 @@ auto.
 Qed.
 
 Goal forall a b c d, a + c <= d -> b <= c -> a + b + c <= c + d.
+Proof.
 intros.
 polr (a + c < d).
 pols.
@@ -126,6 +355,7 @@ auto.
 Qed.
 
 Goal forall a b c d, a + b <= 0 -> 0 <= d -> a + b + c <= c + d.
+Proof.
 intros.
 polrx (0 < d) P.R P.R 1%Z.
 pols.
@@ -135,6 +365,7 @@ auto.
 Qed.
 
 Goal forall a b c d, a + c >= d -> b >= c -> a + b + c >= c + d.
+Proof.
 intros.
 polr (a + c < d).
 pols.
@@ -144,6 +375,7 @@ auto.
 Qed.
 
 Goal forall a b c d, a + b >= 0 -> 0 >= d -> a + b + c >= c + d.
+Proof.
 intros.
 polrx (0 < d) P.R P.R 1%Z.
 pols.
@@ -153,6 +385,7 @@ auto.
 Qed.
 
 Goal forall a b c d, a + c < d -> b <= c -> a + b + c < c + d.
+Proof.
 intros.
 polr (a + c < d).
 pols.
@@ -162,6 +395,7 @@ auto.
 Qed.
 
 Goal forall a b c d, a + b <= 0 -> 0 < d -> a + b + c < c + d.
+Proof.
 intros.
 polrx (0 < d) P.R P.R 1%Z.
 pols.
@@ -169,208 +403,19 @@ auto.
 pols.
 auto.
 Qed.
-
-Goal forall a b c d, a + c > d -> c <= b -> a + b + c > c + d.
-intros.
-polr (a + c < d).
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Goal forall a b c d, 0 <= a + b -> 0 > d -> a + b + c > c + d.
-intros.
-polrx (0 < d) P.R P.R 1%Z.
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Require Import Arith.
-(* Test for Nat *)
-Open Scope  nat_scope.
-
-Goal forall a b c d, a + c = d -> b = c -> a + b + c = c + d.
-intros.
-polr (a + c = d).
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Goal forall a b c d, 0 = d -> a + b = 0 -> a + b + c = c + d.
-intros.
-polr (d = 0).
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Goal forall a b c d, a + c <= d -> b <= c -> a + b + c <= c + d.
-intros.
-polr (a + c < d).
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Goal forall a b c d, a + b <= 0 -> 0 <= d -> a + b + c <= c + d.
-intros.
-polrx (0 < d) P.R P.R 1%Z.
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Goal forall a b c d, a + c <= d -> b <= c -> a + b + c <= c + d.
-intros.
-polr (a + c < d).
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Goal forall a b c d, a + b >= 0 -> 0 >= d -> a + b + c >= c + d.
-intros.
-polrx (0 < d) P.R P.R 1%Z. 
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Goal forall a b c d, a + c < d -> b <= c -> a + b + c < c + d.
-intros.
-polr (a + c < d).
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Goal forall a b c d, a + b <= 0 -> 0 < d -> a + b + c < c + d.
-intros.
-polrx (0 < d) P.R P.R 1%Z.
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Goal forall a b c d, a + c > d -> c <= b -> a + b + c > c + d.
-intros.
-(*
-NatPolR.npolrx (a + c < d) P.L P.L 1%Z.
-*)
-polr (a + c < d).
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Goal forall a b c d, 0 <= a + b -> 0 > d -> a + b + c > c + d.
-intros.
-polrx (0 < d) P.R P.R 1%Z.
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-(* Test for R *)
-Require Import Reals.
-Open Scope  R_scope.
-
-Goal forall a b c d, a + c = d -> b = c -> a + b + c = c + d.
-intros.
-polr (a + c = d).
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Goal forall a b c d, 0 = d -> a + b = 0 -> a + b + c = c + d.
-intros.
-polr (d = 0).
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Goal forall a b c d, a + c <= d -> b <= c -> a + b + c <= c + d.
-intros.
-polr (a + c < d).
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Goal forall a b c d, a + b <= 0 -> 0 <= d -> a + b + c <= c + d.
-intros.
-polrx (0 < d) P.R P.R 1%Z.
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Goal forall a b c d, a + c >= d -> b >= c -> a + b + c >= c + d.
-intros.
-polr (a + c < d).
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Goal forall a b c d, a + b >= 0 -> 0 >= d -> a + b + c >= c + d.
-intros.
-polrx (0 < d) P.R P.R 1%Z.
-pols.
-auto.
-pols.
-auto.
-Qed.
-
-Goal forall a b c d, a + c < d -> b <= c -> a + b + c < c + d.
-intros.
-polr (a + c < d).
-pols.
-auto.
-pols.
-auto.
-Qed.
- 
-Goal forall a b c d, a + b <= 0 -> 0 < d -> a + b + c < c + d.
-intros.
-polrx (0 < d) P.R P.R 1%Z.
-pols.
-auto.
-pols.
-auto.
-Qed. 
 
 Goal forall a b c d, a + c > d -> b >= c -> a + b + c > c + d.
+Proof.
 intros.
 polr (a + c < d).
 pols.
 auto.
 pols.
 auto.
-Qed. 
+Qed.
 
 Goal forall a b c d, a + b >= 0 -> 0 > d -> a + b + c > c + d.
+Proof.
 intros.
 polrx (0 < d) P.R P.R 1%Z.
 pols.
@@ -378,3 +423,5 @@ auto.
 pols.
 auto.
 Qed.
+
+Close Scope Z_scope.

--- a/Rex.v
+++ b/Rex.v
@@ -2,53 +2,69 @@ Require Import Reals.
 Require Import PolTac.
 
 Open Scope R_scope.
- 
-Theorem pols_test1: forall (x y : R), x < y ->  (x + x < y + x).
+
+Theorem pols_test1 x y :
+  x < y -> x + x < y + x.
+Proof.
 intros.
 pols.
 auto.
 Qed.
- 
-Theorem pols_test2: forall (x y : R), 0 < y ->  (x  < x + y).
+
+Theorem pols_test2 x y :
+  0 < y -> x < x + y.
+Proof.
 intros.
 pols.
 auto.
 Qed.
- 
-Theorem pols_test3: forall (x y : R), 0 < y * y ->  ((x + y) * (x - y) < x * x).
+
+Theorem pols_test3 x y :
+  0 < y * y ->
+  (x + y) * (x - y) < x * x.
+Proof.
 intros.
 pols.
 auto with real.
 Qed.
 
-Theorem pols_test4:
- forall (x y : R),
- x * x  < y * y ->  ((x + y) * (x + y) < 2 * (x * y + y * y)).
-intros.
-pols.
-auto.
-Qed.
- 
-Theorem pols_test5:
- forall (x y z : R),
- x * (z + 2) < y * (2 * x + 1)->  (x * ((z + y) + 2) < y * (3 * x + 1)).
+Theorem pols_test4 x y :
+  x * x < y * y ->
+  (x + y) * (x + y) < 2 * (x * y + y * y).
+Proof.
 intros.
 pols.
 auto.
 Qed.
 
-Theorem polf_test1: forall x y, (0 <= x -> 1 <= y -> x  <=  x  * y)%R.
+Theorem pols_test5 x y z :
+  x * (z + 2) < y * (2 * x + 1) ->
+  x * (z + y + 2) < y * (3 * x + 1).
+Proof.
+intros.
+pols.
+auto.
+Qed.
+
+Theorem polf_test1 x y :
+  0 <= x -> 1 <= y -> x <= x * y.
+Proof.
 intros.
 polf.
 Qed.
 
-Theorem polf_test2: forall x y, (0 < x -> x  <= x  * y -> 1 <= y)%R.
-intros.
-hyp_polf H0.
+Theorem polf_test2 x y :
+  0 < x -> x <= x * y -> 1 <= y.
+Proof.
+intros H1 H2.
+hyp_polf H2.
 Qed.
 
-Theorem polr_test1: forall x y z, (x + z) < y -> x + y + z < 2*y.
-intros x y z H.
+Theorem polr_test1 x y z :
+  x + z < y ->
+  x + y + z < 2 * y.
+Proof.
+intros H.
 polr H.
 pols.
 auto.
@@ -56,15 +72,17 @@ pols.
 auto with real.
 Qed.
 
-Theorem polr_test2: forall x y z t u, t <0 -> y = u -> x + z <  y ->  2* y * t <  x * t + t * u + z * t .
-intros x y z t u H H1 H2.
+Theorem polr_test2 x y z t u :
+  t < 0 -> y = u ->
+  x + z < y ->
+  2 * y * t < x * t + t * u + z * t.
+Proof.
+intros H1 H2 H3.
 polf.
-polr H1; auto with real.
-polr H2.
+polr H2; auto with real.
+polr H3.
 pols.
 auto.
 pols.
 auto with real.
 Qed.
-
-

--- a/ZAux.v
+++ b/ZAux.v
@@ -1,236 +1,283 @@
 Require Export ZArith.
 
+Open Scope Z_scope.
+
 Theorem Zplus_eq_compat_l: forall a b c:Z, (b = c -> a + b = a + c)%Z.
+Proof.
 intros; apply f_equal2 with (f := Zplus); auto.
 Qed.
 
 Theorem Zplus_neg_compat_l: forall a b c: Z, (b <> c -> a + b <> a + c)%Z.
+Proof.
 intros a b c H H1; case H.
 apply Zplus_reg_l with a; auto.
 Qed.
 
 Theorem Zplus_ge_compat_l: forall n m p : Z, (n >= m -> p + n >= p + m)%Z.
+Proof.
 intros n m p H; apply Z.le_ge; apply Zplus_le_compat_l; auto; apply Z.ge_le; auto.
 Qed.
 
-Theorem Zplus_neg_reg_l: forall a b c: Z,  (a + b <> a + c -> b <> c)%Z.
+Theorem Zplus_neg_reg_l: forall a b c: Z, (a + b <> a + c -> b <> c)%Z.
+Proof.
 intros a b c H H1; case H; subst; auto.
 Qed.
 
 Theorem Zplus_ge_reg_l: forall n m p : Z, (p + n >= p + m -> n >= m)%Z.
+Proof.
 intros n m p H; apply Z.le_ge; apply Zplus_le_reg_l with p; auto; apply Z.ge_le; auto.
 Qed.
 
 (* Theorems to simplify the goal 0 ? x * y and x * y ? 0 where ? is < > <= >= *)
 
-Theorem Zle_sign_pos_pos: forall x y: Z, (0 <= x -> 0 <= y  -> 0 <= x * y)%Z.
+Theorem Zle_sign_pos_pos: forall x y: Z, (0 <= x -> 0 <= y -> 0 <= x * y)%Z.
+Proof.
 auto with zarith.
 Qed.
 
-Theorem Zle_sign_neg_neg: forall x y: Z, (x <= 0 -> y <= 0  -> 0 <= x * y)%Z.
+Theorem Zle_sign_neg_neg: forall x y: Z, (x <= 0 -> y <= 0 -> 0 <= x * y)%Z.
+Proof.
 intros x y H1 H2; replace (x * y)%Z with (-x * -y)%Z; auto with zarith; ring.
 Qed.
 
 Theorem Zopp_le: forall n m, (m <= n -> -n <= -m)%Z.
+Proof.
 auto with zarith.
 Qed.
 
 Theorem Zle_pos_neg: forall x, (0 <= -x -> x <= 0)%Z.
+Proof.
 auto with zarith.
 Qed.
 
-Theorem Zle_sign_pos_neg: forall x y: Z, (0 <= x -> y <= 0  -> x * y <= 0)%Z.
+Theorem Zle_sign_pos_neg: forall x y: Z, (0 <= x -> y <= 0 -> x * y <= 0)%Z.
+Proof.
 intros x y H1 H2; apply Zle_pos_neg; replace (- (x * y))%Z with (x * (- y))%Z; auto with zarith; ring.
 Qed.
 
-Theorem Zle_sign_neg_pos: forall x y: Z, (x <= 0 -> 0 <= y  -> x * y <= 0)%Z.
+Theorem Zle_sign_neg_pos: forall x y: Z, (x <= 0 -> 0 <= y -> x * y <= 0)%Z.
+Proof.
 intros x y H1 H2; apply Zle_pos_neg; replace (- (x * y))%Z with (-x * y)%Z; auto with zarith; ring.
 Qed.
 
 
-Theorem Zlt_sign_pos_pos: forall x y: Z, (0 < x -> 0 < y  -> 0 < x * y)%Z.
+Theorem Zlt_sign_pos_pos: forall x y: Z, (0 < x -> 0 < y -> 0 < x * y)%Z.
+Proof.
 intros; apply Zmult_lt_O_compat; auto with zarith.
 Qed.
 
-Theorem Zlt_sign_neg_neg: forall x y: Z, (x < 0 -> y < 0  -> 0 < x * y)%Z.
+Theorem Zlt_sign_neg_neg: forall x y: Z, (x < 0 -> y < 0 -> 0 < x * y)%Z.
+Proof.
 intros x y H1 H2; replace (x * y)%Z with (-x * -y)%Z; auto with zarith; try ring.
 apply Zmult_lt_O_compat; auto with zarith.
 Qed.
 
 Theorem Zlt_pos_neg: forall x, (0 < -x -> x < 0)%Z.
+Proof.
 auto with zarith.
 Qed.
 
-Theorem Zlt_sign_pos_neg: forall x y: Z, (0 < x -> y < 0  -> x * y < 0)%Z.
+Theorem Zlt_sign_pos_neg: forall x y: Z, (0 < x -> y < 0 -> x * y < 0)%Z.
+Proof.
 intros x y H1 H2; apply Zlt_pos_neg; replace (- (x * y))%Z with (x * (- y))%Z; auto with zarith; try ring.
 apply Zmult_lt_O_compat; auto with zarith.
 Qed.
 
-Theorem Zlt_sign_neg_pos: forall x y: Z, (x < 0 -> 0 < y  -> x * y < 0)%Z.
+Theorem Zlt_sign_neg_pos: forall x y: Z, (x < 0 -> 0 < y -> x * y < 0)%Z.
+Proof.
 intros x y H1 H2; apply Zlt_pos_neg; replace (- (x * y))%Z with (-x * y)%Z; auto with zarith; try ring.
 apply Zmult_lt_O_compat; auto with zarith.
 Qed.
 
-Theorem Zge_sign_neg_neg: forall x y: Z, (0 >= x -> 0 >= y  -> x * y >= 0)%Z.
+Theorem Zge_sign_neg_neg: forall x y: Z, (0 >= x -> 0 >= y -> x * y >= 0)%Z.
+Proof.
 intros; apply Z.le_ge; apply Zle_sign_neg_neg; auto with zarith.
 Qed.
 
-Theorem Zge_sign_pos_pos: forall x y: Z, (x >= 0 -> y >= 0  -> x * y >= 0)%Z.
+Theorem Zge_sign_pos_pos: forall x y: Z, (x >= 0 -> y >= 0 -> x * y >= 0)%Z.
+Proof.
 intros; apply Z.le_ge; apply Zle_sign_pos_pos; auto with zarith.
 Qed.
 
 Theorem Zge_neg_pos: forall x, (0 >= -x -> x >= 0)%Z.
+Proof.
 auto with zarith.
 Qed.
 
-Theorem Zge_sign_neg_pos: forall x y: Z, (0 >= x -> y >= 0  -> 0>= x * y)%Z.
+Theorem Zge_sign_neg_pos: forall x y: Z, (0 >= x -> y >= 0 -> 0 >= x * y)%Z.
+Proof.
 intros; apply Z.le_ge; apply Zle_sign_neg_pos; auto with zarith.
 Qed.
 
-Theorem Zge_sign_pos_neg: forall x y: Z, (x >= 0 -> 0 >= y  -> 0 >= x * y)%Z.
+Theorem Zge_sign_pos_neg: forall x y: Z, (x >= 0 -> 0 >= y -> 0 >= x * y)%Z.
+Proof.
 intros; apply Z.le_ge; apply Zle_sign_pos_neg; auto with zarith.
 Qed.
 
 
-Theorem Zgt_sign_neg_neg: forall x y: Z, (0 > x -> 0 > y  -> x * y > 0)%Z.
+Theorem Zgt_sign_neg_neg: forall x y: Z, (0 > x -> 0 > y -> x * y > 0)%Z.
+Proof.
 intros; apply Z.lt_gt; apply Zlt_sign_neg_neg; auto with zarith.
 Qed.
 
-Theorem Zgt_sign_pos_pos: forall x y: Z, (x > 0 -> y > 0  -> x * y > 0)%Z.
+Theorem Zgt_sign_pos_pos: forall x y: Z, (x > 0 -> y > 0 -> x * y > 0)%Z.
+Proof.
 intros; apply Z.lt_gt; apply Zlt_sign_pos_pos; auto with zarith.
 Qed.
 
 Theorem Zgt_neg_pos: forall x, (0 > -x -> x > 0)%Z.
+Proof.
 auto with zarith.
 Qed.
 
-Theorem Zgt_sign_neg_pos: forall x y: Z, (0 > x -> y > 0  -> 0> x * y)%Z.
+Theorem Zgt_sign_neg_pos: forall x y: Z, (0 > x -> y > 0 -> 0> x * y)%Z.
+Proof.
 intros; apply Z.lt_gt; apply Zlt_sign_neg_pos; auto with zarith.
 Qed.
 
-Theorem Zgt_sign_pos_neg: forall x y: Z, (x > 0 -> 0 > y  -> 0 > x * y)%Z.
+Theorem Zgt_sign_pos_neg: forall x y: Z, (x > 0 -> 0 > y -> 0 > x * y)%Z.
+Proof.
 intros; apply Z.lt_gt; apply Zlt_sign_pos_neg; auto with zarith.
 Qed.
 
 (* Theorems to simplify the hyp 0 ? x * y and x * y ? 0 where ? is < > <= >= *)
 
 Theorem Zle_sign_pos_pos_rev: forall x y: Z, (0 < x -> 0 <= x * y -> 0 <= y)%Z.
+Proof.
 intros x y H1 H2; case (Zle_or_lt 0 y); auto with zarith.
 intros H3; absurd (0 <= x * y)%Z; auto with zarith.
 apply Zlt_not_le;apply Zlt_sign_pos_neg; auto.
 Qed.
 
-Theorem Zle_sign_neg_neg_rev: forall x y: Z, (x < 0 -> 0 <= x * y ->  y <= 0)%Z.
-intros x y H1 H2; case (Zle_or_lt y  0); auto with zarith.
+Theorem Zle_sign_neg_neg_rev: forall x y: Z, (x < 0 -> 0 <= x * y -> y <= 0)%Z.
+Proof.
+intros x y H1 H2; case (Zle_or_lt y 0); auto with zarith.
 intros H3; absurd (0 <= x * y)%Z; auto with zarith.
 apply Zlt_not_le;apply Zlt_sign_neg_pos; auto.
 Qed.
 
 Theorem Zle_sign_pos_neg_rev: forall x y: Z, (0 < x -> x * y <= 0 -> y <= 0)%Z.
+Proof.
 intros x y H1 H2; case (Zle_or_lt y 0); auto with zarith.
 intros H3; absurd (x * y <= 0)%Z; auto with zarith.
 apply Zlt_not_le;apply Zlt_sign_pos_pos; auto.
 Qed.
 
-Theorem Zle_sign_neg_pos_rev: forall x y: Z, (x < 0 -> x * y <= 0 ->  0 <= y)%Z.
+Theorem Zle_sign_neg_pos_rev: forall x y: Z, (x < 0 -> x * y <= 0 -> 0 <= y)%Z.
+Proof.
 intros x y H1 H2; case (Zle_or_lt 0 y); auto with zarith.
 intros H3; absurd (x * y <= 0)%Z; auto with zarith.
 apply Zlt_not_le;apply Zlt_sign_neg_neg; auto.
 Qed.
 
 Theorem Zge_sign_pos_pos_rev: forall x y: Z, (x > 0 -> x * y >= 0 -> y >= 0)%Z.
+Proof.
 intros x y H1 H2; apply Z.le_ge; apply Zle_sign_pos_pos_rev with x; auto with zarith.
 Qed.
 
-Theorem Zge_sign_neg_neg_rev: forall x y: Z, (0 > x -> x * y  >= 0->  0 >= y)%Z.
+Theorem Zge_sign_neg_neg_rev: forall x y: Z, (0 > x -> x * y >= 0 -> 0 >= y)%Z.
+Proof.
 intros x y H1 H2; apply Z.le_ge; apply Zle_sign_neg_neg_rev with x; auto with zarith.
 Qed.
 
 Theorem Zge_sign_pos_neg_rev: forall x y: Z, (x > 0 -> 0 >= x * y -> 0 >= y)%Z.
+Proof.
 intros x y H1 H2; apply Z.le_ge; apply Zle_sign_pos_neg_rev with x; auto with zarith.
 Qed.
 
-Theorem Zge_sign_neg_pos_rev: forall x y: Z, (0 > x -> 0 >= x * y ->  y >= 0)%Z.
+Theorem Zge_sign_neg_pos_rev: forall x y: Z, (0 > x -> 0 >= x * y -> y >= 0)%Z.
+Proof.
 intros x y H1 H2; apply Z.le_ge; apply Zle_sign_neg_pos_rev with x; auto with zarith.
 Qed.
 
 Theorem Zlt_sign_pos_pos_rev: forall x y: Z, (0 < x -> 0 < x * y -> 0 < y)%Z.
+Proof.
 intros x y H1 H2; case (Zle_or_lt y 0); auto with zarith.
 intros H3; absurd (0 < x * y)%Z; auto with zarith.
 apply Zle_not_lt;apply Zle_sign_pos_neg; auto with zarith.
 Qed.
 
-Theorem Zlt_sign_neg_neg_rev: forall x y: Z, (x < 0 -> 0 < x * y ->  y < 0)%Z.
+Theorem Zlt_sign_neg_neg_rev: forall x y: Z, (x < 0 -> 0 < x * y -> y < 0)%Z.
+Proof.
 intros x y H1 H2; case (Zle_or_lt 0 y); auto with zarith.
 intros H3; absurd (0 < x * y)%Z; auto with zarith.
 apply Zle_not_lt;apply Zle_sign_neg_pos; auto with zarith.
 Qed.
 
 Theorem Zlt_sign_pos_neg_rev: forall x y: Z, (0 < x -> x * y < 0 -> y < 0)%Z.
+Proof.
 intros x y H1 H2; case (Zle_or_lt 0 y); auto with zarith.
 intros H3; absurd (x * y < 0)%Z; auto with zarith.
 apply Zle_not_lt;apply Zle_sign_pos_pos; auto with zarith.
 Qed.
 
-Theorem Zlt_sign_neg_pos_rev: forall x y: Z, (x < 0 -> x * y < 0 ->  0 < y)%Z.
+Theorem Zlt_sign_neg_pos_rev: forall x y: Z, (x < 0 -> x * y < 0 -> 0 < y)%Z.
+Proof.
 intros x y H1 H2; case (Zle_or_lt y 0); auto with zarith.
 intros H3; absurd (x * y < 0)%Z; auto with zarith.
 apply Zle_not_lt;apply Zle_sign_neg_neg; auto with zarith.
 Qed.
 
 Theorem Zgt_sign_pos_pos_rev: forall x y: Z, (x > 0 -> x * y > 0 -> y > 0)%Z.
+Proof.
 intros x y H1 H2; apply Z.lt_gt; apply Zlt_sign_pos_pos_rev with x; auto with zarith.
 Qed.
 
-Theorem Zgt_sign_neg_neg_rev: forall x y: Z, (0 > x -> x * y  > 0->  0 > y)%Z.
+Theorem Zgt_sign_neg_neg_rev: forall x y: Z, (0 > x -> x * y > 0 -> 0 > y)%Z.
+Proof.
 intros x y H1 H2; apply Z.lt_gt; apply Zlt_sign_neg_neg_rev with x; auto with zarith.
 Qed.
 
 Theorem Zgt_sign_pos_neg_rev: forall x y: Z, (x > 0 -> 0 > x * y -> 0 > y)%Z.
+Proof.
 intros x y H1 H2; apply Z.lt_gt; apply Zlt_sign_pos_neg_rev with x; auto with zarith.
 Qed.
 
-Theorem Zgt_sign_neg_pos_rev: forall x y: Z, (0 > x -> 0 > x * y ->  y > 0)%Z.
+Theorem Zgt_sign_neg_pos_rev: forall x y: Z, (0 > x -> 0 > x * y -> y > 0)%Z.
+Proof.
 intros x y H1 H2; apply Z.lt_gt; apply Zlt_sign_neg_pos_rev with x; auto with zarith.
 Qed.
 
 (* Theorem to simplify x * y ? x * z where ? is < > <= >= *)
 
-Theorem Zmult_le_neg_compat_l:
-  forall n m p : Z, (m <= n)%Z -> (p <= 0)%Z -> (p * n <= p * m)%Z.
+Theorem Zmult_le_neg_compat_l: forall n m p : Z, (m <= n)%Z -> (p <= 0)%Z -> (p * n <= p * m)%Z.
+Proof.
 intros n m p H1 H2; replace (p * n)%Z with (-(-p * n))%Z; auto with zarith; try ring.
 replace (p * m)%Z with (-(-p * m))%Z; auto with zarith; try ring.
 apply Zopp_le; apply Zmult_le_compat_l; auto with zarith.
 Qed.
 
 Theorem Zopp_lt: forall n m, (m < n -> -n < -m)%Z.
+Proof.
 auto with zarith.
 Qed.
 
-Theorem Zmult_lt_neg_compat_l:
-  forall n m p : Z, (m < n)%Z -> (p < 0)%Z -> (p * n < p * m)%Z.
+Theorem Zmult_lt_neg_compat_l: forall n m p : Z, (m < n)%Z -> (p < 0)%Z -> (p * n < p * m)%Z.
+Proof.
 intros n m p H1 H2; replace (p * n)%Z with (-(-p * n))%Z; auto with zarith; try ring.
 replace (p * m)%Z with (-(-p * m))%Z; auto with zarith; try ring.
 apply Zopp_lt; apply Zmult_lt_compat_l; auto with zarith.
 Qed.
 
 Theorem Zopp_ge: forall n m, (m >= n -> -n >= -m)%Z.
+Proof.
 auto with zarith.
 Qed.
 
-Theorem Zmult_ge_neg_compat_l:
-  forall n m p : Z, (m >= n)%Z -> (0 >= p)%Z -> (p * n >= p * m)%Z.
+Theorem Zmult_ge_neg_compat_l: forall n m p : Z, (m >= n)%Z -> (0 >= p)%Z -> (p * n >= p * m)%Z.
+Proof.
 intros n m p H1 H2; replace (p * n)%Z with (-(-p * n))%Z; auto with zarith; try ring.
 replace (p * m)%Z with (-(-p * m))%Z; auto with zarith; try ring.
 apply Zopp_ge; apply Zmult_ge_compat_l; auto with zarith.
 Qed.
 
 Theorem Zopp_gt: forall n m, (m > n -> -n > -m)%Z.
+Proof.
 auto with zarith.
 Qed.
 
-Theorem Zmult_gt_neg_compat_l:
-  forall n m p : Z, (m > n)%Z -> (0 > p)%Z -> (p * n > p * m)%Z.
+Theorem Zmult_gt_neg_compat_l: forall n m p : Z, (m > n)%Z -> (0 > p)%Z -> (p * n > p * m)%Z.
+Proof.
 intros n m p H1 H2; replace (p * n)%Z with (-(-p * n))%Z; auto with zarith; try ring.
 replace (p * m)%Z with (-(-p * m))%Z; auto with zarith; try ring.
 apply Zopp_gt; apply Zmult_gt_compat_l; auto with zarith.
@@ -239,55 +286,54 @@ Qed.
 
 (* Theorem to simplify a hyp x * y ? x * z where ? is < > <= >= *)
 
-
-Theorem Zmult_le_compat_l_rev:
-  forall n m p : Z, (0 < p)%Z -> (p * n <= p * m)%Z -> (n <= m)%Z.
+Theorem Zmult_le_compat_l_rev: forall n m p : Z, (0 < p)%Z -> (p * n <= p * m)%Z -> (n <= m)%Z.
+Proof.
 intros n m p H H1; case (Zle_or_lt n m); auto; intros H2.
 absurd (p * n <= p * m)%Z; auto with zarith.
 apply Zlt_not_le; apply Zmult_lt_compat_l; auto.
 Qed.
 
-Theorem Zmult_le_neg_compat_l_rev:
-  forall n m p : Z, (p < 0)%Z -> (p * n <= p * m)%Z -> (m <= n)%Z.
+Theorem Zmult_le_neg_compat_l_rev: forall n m p : Z, (p < 0)%Z -> (p * n <= p * m)%Z -> (m <= n)%Z.
+Proof.
 intros n m p H H1; case (Zle_or_lt m n); auto; intros H2.
 absurd (p * n <= p * m)%Z; auto with zarith.
 apply Zlt_not_le; apply Zmult_lt_neg_compat_l; auto.
 Qed.
 
-Theorem Zmult_lt_compat_l_rev:
-  forall n m p : Z, (0 < p)%Z -> (p * n < p * m)%Z -> (n < m)%Z.
+Theorem Zmult_lt_compat_l_rev: forall n m p : Z, (0 < p)%Z -> (p * n < p * m)%Z -> (n < m)%Z.
+Proof.
 intros n m p H H1; case (Zle_or_lt m n); auto; intros H2.
 absurd (p * n < p * m)%Z; auto with zarith.
 apply Zle_not_lt; apply Zmult_le_compat_l; auto with zarith.
 Qed.
 
-Theorem Zmult_lt_neg_compat_l_rev:
-  forall n m p : Z, (p < 0)%Z -> (p * n < p * m)%Z -> (m < n)%Z.
+Theorem Zmult_lt_neg_compat_l_rev: forall n m p : Z, (p < 0)%Z -> (p * n < p * m)%Z -> (m < n)%Z.
+Proof.
 intros n m p H H1; case (Zle_or_lt n m); auto; intros H2.
 absurd (p * n < p * m)%Z; auto with zarith.
 apply Zle_not_lt; apply Zmult_le_neg_compat_l; auto with zarith.
 Qed.
 
-Theorem Zmult_ge_compat_l_rev:
-  forall n m p : Z, (p > 0)%Z -> (p * n >= p * m)%Z -> (n >= m)%Z.
+Theorem Zmult_ge_compat_l_rev: forall n m p : Z, (p > 0)%Z -> (p * n >= p * m)%Z -> (n >= m)%Z.
+Proof.
 intros n m p H H1;
- apply Z.le_ge; apply Zmult_le_compat_l_rev with p; auto with zarith.
+  apply Z.le_ge; apply Zmult_le_compat_l_rev with p; auto with zarith.
 Qed.
 
-Theorem Zmult_ge_neg_compat_l_rev:
-  forall n m p : Z, (0 > p)%Z -> (p * n >= p * m)%Z -> (m >= n)%Z.
+Theorem Zmult_ge_neg_compat_l_rev: forall n m p : Z, (0 > p)%Z -> (p * n >= p * m)%Z -> (m >= n)%Z.
+Proof.
 intros n m p H H1;
- apply Z.le_ge; apply Zmult_le_neg_compat_l_rev with p; auto with zarith.
+  apply Z.le_ge; apply Zmult_le_neg_compat_l_rev with p; auto with zarith.
 Qed.
 
-Theorem Zmult_gt_compat_l_rev:
-  forall n m p : Z, (p > 0)%Z -> (p * n > p * m)%Z -> (n > m)%Z.
+Theorem Zmult_gt_compat_l_rev: forall n m p : Z, (p > 0)%Z -> (p * n > p * m)%Z -> (n > m)%Z.
+Proof.
 intros n m p H H1;
- apply Z.lt_gt; apply Zmult_lt_compat_l_rev with p; auto with zarith.
+  apply Z.lt_gt; apply Zmult_lt_compat_l_rev with p; auto with zarith.
 Qed.
 
-Theorem Zmult_gt_neg_compat_l_rev:
-  forall n m p : Z, (0 > p)%Z -> (p * n > p * m)%Z -> (m > n)%Z.
+Theorem Zmult_gt_neg_compat_l_rev: forall n m p : Z, (0 > p)%Z -> (p * n > p * m)%Z -> (m > n)%Z.
+Proof.
 intros n m p H H1;
- apply Z.lt_gt; apply Zmult_lt_neg_compat_l_rev with p; auto with zarith.
+  apply Z.lt_gt; apply Zmult_lt_neg_compat_l_rev with p; auto with zarith.
 Qed.

--- a/ZPolF.v
+++ b/ZPolF.v
@@ -7,63 +7,63 @@ Require Import PolAuxList.
 Require Import ZSignTac.
 
 
-Definition Zfactor := 
+Definition Zfactor :=
   factor Z Zplus Zmult Z.opp 0%Z 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div Zgcd.
 
-Definition Zfactor_minus := 
+Definition Zfactor_minus :=
   factor_sub Z Zplus Zmult Z.opp 0%Z 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div Zgcd.
 
-Definition Zget_delta := 
- get_delta Z Zplus Zmult Z.opp 0%Z 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div Zgcd.
+Definition Zget_delta :=
+  get_delta Z Zplus Zmult Z.opp 0%Z 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div Zgcd.
 
-Ltac
-Zfactor_term term1 term2 :=
-let term := constr:(Zminus term1 term2) in
-let rfv := FV ZCst Zplus Zmult Zminus Z.opp term (@nil Z) in
-let fv := Trev rfv in
-let expr1 := mkPolexpr Z ZCst Zplus Zmult Zminus Z.opp term1 fv in
-let expr2 := mkPolexpr Z ZCst Zplus Zmult Zminus Z.opp term2 fv in
-let re := eval vm_compute in (Zfactor_minus (PEsub expr1 expr2)) in
-let factor := match re with (PEmul ?X1 _) => X1 end in
-let expr3 := match re with (PEmul _ (PEsub ?X1 _)) => X1 end in
-let expr4 := match re with (PEmul _ (PEsub _ ?X1 )) => X1 end in
-let
- re1' :=
-  eval
-     unfold
-      Zconvert_back, convert_back,  pos_nth,  jump, 
-         hd,  tl in (Zconvert_back (PEmul factor expr3) fv) in
-let re1'' := eval lazy beta in re1' in
-let
- re2' :=
-  eval
-     unfold
-      Zconvert_back, convert_back,  pos_nth,  jump, 
-         hd,  tl in (Zconvert_back (PEmul factor expr4) fv) in
-let re2'' := eval lazy beta in re2' in 
-replace2_tac term1 term2 re1'' re2''; [idtac| ring | ring].
+
+Ltac Zfactor_term term1 term2 :=
+  let term := constr:(Zminus term1 term2) in
+  let rfv := FV ZCst Zplus Zmult Zminus Z.opp term (@nil Z) in
+  let fv := Trev rfv in
+  let expr1 := mkPolexpr Z ZCst Zplus Zmult Zminus Z.opp term1 fv in
+  let expr2 := mkPolexpr Z ZCst Zplus Zmult Zminus Z.opp term2 fv in
+  let re := (eval vm_compute in (Zfactor_minus (PEsub expr1 expr2))) in
+  let factor := match re with (PEmul ?X1 _) => X1 end in
+  let expr3 := match re with (PEmul _ (PEsub ?X1 _)) => X1 end in
+  let expr4 := match re with (PEmul _ (PEsub _ ?X1 )) => X1 end in
+  let re1' :=
+      (eval
+         unfold
+         Zconvert_back, convert_back, pos_nth, jump,
+       hd, tl in (Zconvert_back (PEmul factor expr3) fv))
+  in
+  let re1'' := (eval lazy beta in re1') in
+  let re2' :=
+      (eval
+         unfold
+         Zconvert_back, convert_back, pos_nth, jump,
+       hd, tl in (Zconvert_back (PEmul factor expr4) fv))
+  in
+  let re2'' := (eval lazy beta in re2') in
+  replace2_tac term1 term2 re1'' re2''; [idtac | ring | ring].
 
 Ltac zpolf :=
-(* progress *) (
-(try 
-match goal with
-| |- (?X1 = ?X2)%Z =>  Zfactor_term X1 X2 
-| |- (?X1 <> ?X2)%Z =>  Zfactor_term X1 X2 
-| |- Z.lt ?X1 ?X2 => Zfactor_term X1 X2
-| |- Z.gt ?X1 ?X2 =>Zfactor_term X1 X2
-| |- Z.le ?X1 ?X2 => Zfactor_term X1 X2
-| |- Z.ge ?X1 ?X2 =>Zfactor_term X1 X2
-| _ => fail end));  try (zsign_tac); try repeat (rewrite Zmult_1_l || rewrite Zmult_1_r).
+  try match goal with
+      | |- (?X1 = ?X2)%Z => Zfactor_term X1 X2
+      | |- (?X1 <> ?X2)%Z => Zfactor_term X1 X2
+      | |- Z.lt ?X1 ?X2 => Zfactor_term X1 X2
+      | |- Z.gt ?X1 ?X2 => Zfactor_term X1 X2
+      | |- Z.le ?X1 ?X2 => Zfactor_term X1 X2
+      | |- Z.ge ?X1 ?X2 => Zfactor_term X1 X2
+      | _ => fail end;
+  try zsign_tac; try repeat (rewrite Zmult_1_l || rewrite Zmult_1_r).
 
-Ltac hyp_zpolf H := 
-progress (
-generalize H; 
-(try 
-match type of H with
-  (?X1 = ?X2)%Z =>  Zfactor_term X1 X2 
-| (?X1 <> ?X2)%Z =>  Zfactor_term X1 X2 
-| Z.lt ?X1 ?X2 => Zfactor_term X1 X2
-| Z.gt ?X1 ?X2 =>Zfactor_term X1 X2
-| Z.le ?X1 ?X2 => Zfactor_term X1 X2 
-| Z.ge ?X1 ?X2 =>Zfactor_term X1 X2
-| _ => fail end)); clear H; intros H; try hyp_zsign_tac H; try repeat rewrite Zmult_1_l.
+Ltac hyp_zpolf H :=
+  progress
+    (generalize H;
+     try match type of H with
+         | (?X1 = ?X2)%Z => Zfactor_term X1 X2
+         | (?X1 <> ?X2)%Z => Zfactor_term X1 X2
+         | Z.lt ?X1 ?X2 => Zfactor_term X1 X2
+         | Z.gt ?X1 ?X2 => Zfactor_term X1 X2
+         | Z.le ?X1 ?X2 => Zfactor_term X1 X2
+         | Z.ge ?X1 ?X2 => Zfactor_term X1 X2
+         | _ => fail end);
+  clear H; intros H;
+  try hyp_zsign_tac H; try repeat rewrite Zmult_1_l.

--- a/ZPolR.v
+++ b/ZPolR.v
@@ -6,152 +6,153 @@ Require Import ZPolS.
 Require Import ZPolF.
 Require Import PolRBase.
 
- 
+
 Definition Zreplace_term_aux :=
   replace Z Zplus Zmult Z.opp 0%Z 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div.
 
-Ltac
-Zreplace_term term from to occ id :=
-let rfv := FV ZCst Zplus Zmult Zminus Z.opp term (@nil Z) in
-let rfv1 := FV ZCst Zplus Zmult Zminus Z.opp from rfv in
-let rfv2 := FV ZCst Zplus Zmult Zminus Z.opp to rfv1 in
-let fv := Trev rfv2 in
-let expr := mkPolexpr Z ZCst Zplus Zmult Zminus Z.opp term fv in
-let expr_from := mkPolexpr Z ZCst Zplus Zmult Zminus Z.opp from fv in
-let expr_to := mkPolexpr Z ZCst Zplus Zmult Zminus Z.opp to fv in
-let re := eval vm_compute in (Zreplace_term_aux expr expr_from expr_to occ) in
-let term1 := eval
-     unfold Zconvert_back, convert_back,  pos_nth,  jump,
-         hd,  tl in (Zconvert_back re fv) in
-match id with 
-     true => term1
+
+Ltac Zreplace_term term from to occ id :=
+  let rfv := FV ZCst Zplus Zmult Zminus Z.opp term (@nil Z) in
+  let rfv1 := FV ZCst Zplus Zmult Zminus Z.opp from rfv in
+  let rfv2 := FV ZCst Zplus Zmult Zminus Z.opp to rfv1 in
+  let fv := Trev rfv2 in
+  let expr := mkPolexpr Z ZCst Zplus Zmult Zminus Z.opp term fv in
+  let expr_from := mkPolexpr Z ZCst Zplus Zmult Zminus Z.opp from fv in
+  let expr_to := mkPolexpr Z ZCst Zplus Zmult Zminus Z.opp to fv in
+  let re := (eval vm_compute in (Zreplace_term_aux expr expr_from expr_to occ)) in
+  let term1 :=
+      (eval
+         unfold
+         Zconvert_back, convert_back, pos_nth, jump,
+       hd, tl in (Zconvert_back re fv))
+  in
+  match id with
+  | true => term1
   | false =>
-     match eqterm term term1 with
-       |false => term1
+    match eqterm term term1 with
+    | false => term1
     end
-end
-.
+  end.
 
 Ltac zpol_is_compare term :=
-match term with
-| (_ < _)%Z => constr:(true)
-| (_ > _)%Z => constr:(true)
-| (_ <= _)%Z => constr:(true)
-| (_ >= _)%Z => constr:(true)
-| (?X = _)%Z => match type of X with Z => constr:(true) end 
-| _ => constr:(false)
-end.
+  match term with
+  | (_ < _)%Z => constr:(true)
+  | (_ > _)%Z => constr:(true)
+  | (_ <= _)%Z => constr:(true)
+  | (_ >= _)%Z => constr:(true)
+  | (?X = _)%Z => match type of X with Z => constr:(true) end
+  | _ => constr:(false)
+  end.
 
 Ltac zpol_get_term dir term :=
-match term with
-|  (?op ?X  ?Y)%Z =>
-     match dir with P.L => X | P.R => Y end
-|  (?X = ?Y)%Z =>
-     match dir with P.L => X | P.R => Y end
-| _ => fail 1 "Unknown term in zpolget_term"
-end.
+  match term with
+  | (?op ?X ?Y)%Z => match dir with P.L => X | P.R => Y end
+  | (?X = ?Y)%Z => match dir with P.L => X | P.R => Y end
+  | _ => fail 1 "Unknown term in zpolget_term"
+  end.
 
-Ltac zpol_replace_term term1 term2 dir1 dir2 occ id := 
-  let dir2opp := eval vm_compute in (P.pol_dir_opp dir2) in
+Ltac zpol_replace_term term1 term2 dir1 dir2 occ id :=
+  let dir2opp := (eval vm_compute in (P.pol_dir_opp dir2)) in
   let t1 := zpol_get_term dir2 term2 in
   let t2 := match id with true => t1 | false => zpol_get_term dir2opp term2 end in
   match term1 with
-   | (?op ?X ?Y) =>
-     match dir1 with
-         P.L  =>
-             Zreplace_term X t1 t2 occ id
-       | P.R => 
-            Zreplace_term Y t1 t2 occ id
-      end
-  | (?X = ?Y)%Z  =>
-     match dir1 with
-       P.L  =>
-             Zreplace_term X t1 t2 occ id
-     | P.R => 
-             Zreplace_term Y  t1 t2 occ id
-      end
+  | (?op ?X ?Y) =>
+    match dir1 with
+    | P.L => Zreplace_term X t1 t2 occ id
+    | P.R => Zreplace_term Y t1 t2 occ id
+    end
+  | (?X = ?Y)%Z =>
+    match dir1 with
+    | P.L => Zreplace_term X t1 t2 occ id
+    | P.R => Zreplace_term Y t1 t2 occ id
+    end
   end.
-
 
 Ltac zpol_aux_dir term dir :=
   match term with
-   (_ < _)%Z => dir
+  | (_ < _)%Z => dir
   | (_ > _)%Z => dir
-  | (_ <= _)%Z => eval compute in (P.pol_dir_opp dir) 
-  | (_ >= _)%Z  => eval compute in (P.pol_dir_opp dir) 
-end.
+  | (_ <= _)%Z => eval compute in (P.pol_dir_opp dir)
+  | (_ >= _)%Z => eval compute in (P.pol_dir_opp dir)
+  end.
 
 (* Do the replacement *)
 Ltac Zreplace_tac_full term dir1 dir2 occ :=
-match term with
- (?T1 = ?T2)%Z =>
-  (* We have here a substitution *)
-  match goal with
-     |-  ?G => let  t := zpol_replace_term G term dir1 dir2 occ false in
-              match dir1 with
-               P.L =>
-                      apply trans_equal with t ||
-                      apply eq_Zlt_trans_l with t || apply eq_Zgt_trans_l with t ||
-                       apply eq_Zle_trans_l with t || apply eq_Zge_trans_l with t
-              | P.R =>
-                     apply trans_equal_r with t ||
-                       apply eq_Zlt_trans_r with t || apply eq_Zgt_trans_r with t ||
-                       apply eq_Zle_trans_r with t || apply eq_Zge_trans_r with t
-              end
-  end
-| _ =>
-   match goal with
-     |- (?X <= ?Y)%Z  =>
-            let  t := zpol_replace_term (X <= Y)%Z term dir1 dir2 occ false in
-               apply Z.le_trans with t
-     |  |- (?X >= ?Y)%Z =>
-            let  t := zpol_replace_term (X >= Y)%Z term dir1 dir2 occ false in
-               apply Zge_trans with t
-     | |- ?G  =>
-            let  t := zpol_replace_term G term dir1 dir2 occ false in
-           match zpol_aux_dir term dir1 with
-                P.L =>
-                                    (apply Z.lt_le_trans with t || apply Zgt_le_trans with t)
-               |P.R =>
-                                    (apply Z.le_lt_trans with t || apply Zle_gt_trans with t)
-            end
-   end
-end.
+  match term with
+  | (?T1 = ?T2)%Z =>
+    (* We have here a substitution *)
+    match goal with
+    | |- ?G =>
+      let t := zpol_replace_term G term dir1 dir2 occ false in
+      match dir1 with
+      | P.L =>
+        (apply trans_equal with t)
+        || (apply eq_Zlt_trans_l with t)
+        || (apply eq_Zgt_trans_l with t)
+        || (apply eq_Zle_trans_l with t)
+        || (apply eq_Zge_trans_l with t)
+      | P.R =>
+        (apply trans_equal_r with t)
+        || (apply eq_Zlt_trans_r with t)
+        || (apply eq_Zgt_trans_r with t)
+        || (apply eq_Zle_trans_r with t)
+        || (apply eq_Zge_trans_r with t)
+      end
+    end
+  | _ =>
+    match goal with
+    | |- (?X <= ?Y)%Z =>
+      let t := zpol_replace_term (X <= Y)%Z term dir1 dir2 occ false in
+      apply Z.le_trans with t
+    | |- (?X >= ?Y)%Z =>
+      let t := zpol_replace_term (X >= Y)%Z term dir1 dir2 occ false in
+      apply Zge_trans with t
+    | |- ?G =>
+      let t := zpol_replace_term G term dir1 dir2 occ false in
+      match zpol_aux_dir term dir1 with
+      | P.L => apply Z.lt_le_trans with t || apply Zgt_le_trans with t
+      | P.R => apply Z.le_lt_trans with t || apply Zle_gt_trans with t
+      end
+    end
+  end.
 
 (* Make the term appears *)
 Ltac Zreplace_tac_full_id term dir1 dir2 occ :=
   match goal with
-     |-  ?G => let t1 := zpol_replace_term G term dir1 dir2 occ true in 
-                match dir1 with
-                  P.L =>
-                       apply trans_equal with t1 ||
-                       apply eq_Zlt_trans_l with t1 ||
-                       apply eq_Zgt_trans_l with t1 ||
-                       apply eq_Zle_trans_l with t1 ||
-                       apply eq_Zge_trans_l with t1
-               | P.R =>
-                      apply trans_equal_r with t1 ||
-                      apply eq_Zlt_trans_r with t1 ||
-                      apply eq_Zgt_trans_r with t1  ||
-                      apply eq_Zle_trans_r with t1 ||
-                      apply eq_Zge_trans_r with t1
-                end; [ring | idtac]
-end.
+  | |- ?G =>
+    let t1 := zpol_replace_term G term dir1 dir2 occ true in
+    match dir1 with
+    | P.L =>
+      (apply trans_equal with t1)
+      || (apply eq_Zlt_trans_l with t1)
+      || (apply eq_Zgt_trans_l with t1)
+      || (apply eq_Zle_trans_l with t1)
+      || (apply eq_Zge_trans_l with t1)
+    | P.R =>
+      (apply trans_equal_r with t1)
+      || (apply eq_Zlt_trans_r with t1)
+      || (apply eq_Zgt_trans_r with t1)
+      || (apply eq_Zle_trans_r with t1)
+      || (apply eq_Zge_trans_r with t1)
+    end; [ring | idtac]
+  end.
 
 Ltac zpolrx term dir1 dir2 occ :=
-match zpol_is_compare term with
-  true => Zreplace_tac_full_id term dir1 dir2 occ; 
-                [Zreplace_tac_full term dir1 dir2 occ] 
-| false => 
-     let t := type of term in
-     match zpol_is_compare t with true => Zreplace_tac_full_id t dir1 dir2 occ;
-                                                                       [Zreplace_tac_full t dir1 dir2 occ]
-     end 
-end.
+  match zpol_is_compare term with
+  | true =>
+    Zreplace_tac_full_id term dir1 dir2 occ;
+    [Zreplace_tac_full term dir1 dir2 occ]
+  | false =>
+    let t := type of term in
+    match zpol_is_compare t with
+    | true =>
+      Zreplace_tac_full_id t dir1 dir2 occ;
+      [Zreplace_tac_full t dir1 dir2 occ]
+    end
+  end.
 
 Ltac zpolr term :=
-  zpolrx term P.L P.L 1%Z ||
-  zpolrx term P.R P.L 1%Z ||
-  zpolrx term P.L P.R 1%Z ||
-  zpolrx term P.R P.R 1%Z.
-
+  zpolrx term P.L P.L 1%Z
+  || zpolrx term P.R P.L 1%Z
+  || zpolrx term P.L P.R 1%Z
+  || zpolrx term P.R P.R 1%Z.

--- a/ZPolS.v
+++ b/ZPolS.v
@@ -5,78 +5,68 @@ Require Import PolAux.
 
 
 Definition Zconvert_back (e : PExpr Z) (l : list Z) : Z :=
-   convert_back Z Z Z0 Zplus Zminus Zmult Z.opp (fun (x : Z) => x) l e.
+  convert_back Z Z Z0 Zplus Zminus Zmult Z.opp (fun (x : Z) => x) l e.
 
-Definition Zsimpl (e : PExpr Z)  :=
-   simpl
-      Z Zplus Zmult Z.opp Z0 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div e.
-
-Definition Zsimpl_minus (e : PExpr Z) :=
-   simpl_minus
+Definition Zsimpl (e : PExpr Z) :=
+  simpl
     Z Zplus Zmult Z.opp Z0 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div e.
 
-Ltac
-zs term1 term2 :=
-let term := constr:(Zminus term1 term2) in
-let rfv := FV ZCst Zplus Zmult Zminus Z.opp term (@nil Z) in
-let fv := Trev rfv in
-let expr1 := mkPolexpr Z ZCst Zplus Zmult Zminus Z.opp term1 fv in
-let expr2 := mkPolexpr Z ZCst Zplus Zmult Zminus Z.opp term2 fv in
-let re := eval vm_compute in (Zsimpl_minus (PEsub expr1 expr2)) in
-let expr3 := match re with (PEsub ?X1 _) => X1 end in
-let expr4 := match re with (PEsub _ ?X1 ) => X1 end in
-let re1 := eval vm_compute in (Zsimpl (PEsub expr1 expr3)) in
-let
- re1' :=
-  eval
-     unfold
-      Zconvert_back, convert_back,  pos_nth,  jump,
-         hd,  tl in (Zconvert_back (PEadd re1 expr3) fv) in
-let re1'' := eval lazy beta in re1' in
-let
- re2' :=
-  eval
-     unfold
-      Zconvert_back, convert_back,  pos_nth,  jump,
-         hd,  tl in (Zconvert_back (PEadd re1 expr4) fv) in
-let re2'' := eval lazy beta in re2' in
-replace2_tac term1 term2 re1'' re2''; [idtac | ring | ring].
+Definition Zsimpl_minus (e : PExpr Z) :=
+  simpl_minus
+    Z Zplus Zmult Z.opp Z0 1%Z is_Z1 is_Z0 is_Zpos is_Zdiv Z.div e.
 
+Ltac zs term1 term2 :=
+  let term := constr:(Zminus term1 term2) in
+  let rfv := FV ZCst Zplus Zmult Zminus Z.opp term (@nil Z) in
+  let fv := Trev rfv in
+  let expr1 := mkPolexpr Z ZCst Zplus Zmult Zminus Z.opp term1 fv in
+  let expr2 := mkPolexpr Z ZCst Zplus Zmult Zminus Z.opp term2 fv in
+  let re := (eval vm_compute in (Zsimpl_minus (PEsub expr1 expr2))) in
+  let expr3 := match re with (PEsub ?X1 _) => X1 end in
+  let expr4 := match re with (PEsub _ ?X1) => X1 end in
+  let re1 := (eval vm_compute in (Zsimpl (PEsub expr1 expr3))) in
+  let re1' :=
+      (eval
+         unfold
+         Zconvert_back, convert_back, pos_nth, jump,
+       hd, tl in (Zconvert_back (PEadd re1 expr3) fv))
+  in
+  let re1'' := (eval lazy beta in re1') in
+  let re2' :=
+      (eval
+         unfold
+         Zconvert_back, convert_back, pos_nth, jump,
+       hd, tl in (Zconvert_back (PEadd re1 expr4) fv))
+  in
+  let re2'' := (eval lazy beta in re2') in
+  replace2_tac term1 term2 re1'' re2''; [idtac | ring | ring].
 
+Ltac zpols :=
+  match goal with
+  | |- (?X1 = ?X2)%Z => zs X1 X2; apply Zplus_eq_compat_l
+  | |- (?X1 <> ?X2)%Z => zs X1 X2; apply Zplus_neg_compat_l
+  | |- Z.lt ?X1 ?X2 => zs X1 X2; apply Zplus_lt_compat_l
+  | |- Z.gt ?X1 ?X2 => zs X1 X2; apply Zplus_gt_compat_l
+  | |- Z.le ?X1 ?X2 => zs X1 X2; apply Zplus_le_compat_l
+  | |- Z.ge ?X1 ?X2 => zs X1 X2; apply Zplus_ge_compat_l
+  | _ => fail
+  end.
 
-Ltac
-zpols :=
-match goal with
-| |- (?X1 = ?X2)%Z =>
-zs X1 X2; apply Zplus_eq_compat_l
-| |- (?X1 <> ?X2)%Z =>
-zs X1 X2; apply Zplus_neg_compat_l
-| |- Z.lt ?X1 ?X2 =>
-zs X1 X2; apply Zplus_lt_compat_l
-| |- Z.gt ?X1 ?X2 =>
-zs X1 X2; apply Zplus_gt_compat_l
-| |- Z.le ?X1 ?X2 =>
-zs X1 X2; apply Zplus_le_compat_l
-| |- Z.ge ?X1 ?X2 =>
-zs X1 X2; apply Zplus_ge_compat_l
-| _ => fail end.
-
-
-Ltac
-hyp_zpols H :=
-generalize H;
-let tmp := fresh "tmp" in
-match (type of H) with
-   (?X1 = ?X2)%Z =>
-zs X1 X2; intros tmp; generalize (Zplus_reg_l _ _ _ tmp); clear H tmp; intro H
-|  (?X1 <> ?X2)%nat =>
-zs X1 X2; intros tmp; generalize (Zplus_neg_reg_l _ _ _ tmp); clear H tmp; intro H
-|  Z.lt ?X1 ?X2 =>
-zs X1 X2; intros tmp; generalize (Zplus_lt_reg_l _ _ _ tmp); clear H tmp; intro H
-|  Z.gt ?X1 ?X2 =>
-zs X1 X2; intros tmp; generalize (Zplus_gt_reg_l _ _ _ tmp); clear H tmp; intro H
-|  Z.le ?X1 ?X2 =>
-zs X1 X2; intros tmp; generalize (Zplus_le_reg_l _ _ _ tmp); clear H tmp; intro H
-|  Z.ge ?X1 ?X2 =>
-zs X1 X2; intros tmp; generalize (Zplus_ge_reg_l _ _ _ tmp); clear H tmp; intro H
-| _ => fail end.
+Ltac hyp_zpols H :=
+  generalize H;
+  let tmp := fresh "tmp" in
+  match (type of H) with
+  | (?X1 = ?X2)%Z =>
+    zs X1 X2; intros tmp; generalize (Zplus_reg_l _ _ _ tmp); clear H tmp; intro H
+  | (?X1 <> ?X2)%nat =>
+    zs X1 X2; intros tmp; generalize (Zplus_neg_reg_l _ _ _ tmp); clear H tmp; intro H
+  | Z.lt ?X1 ?X2 =>
+    zs X1 X2; intros tmp; generalize (Zplus_lt_reg_l _ _ _ tmp); clear H tmp; intro H
+  | Z.gt ?X1 ?X2 =>
+    zs X1 X2; intros tmp; generalize (Zplus_gt_reg_l _ _ _ tmp); clear H tmp; intro H
+  | Z.le ?X1 ?X2 =>
+    zs X1 X2; intros tmp; generalize (Zplus_le_reg_l _ _ _ tmp); clear H tmp; intro H
+  | Z.ge ?X1 ?X2 =>
+    zs X1 X2; intros tmp; generalize (Zplus_ge_reg_l _ _ _ tmp); clear H tmp; intro H
+  | _ => fail
+  end.

--- a/ZSignTac.v
+++ b/ZSignTac.v
@@ -1,377 +1,379 @@
 (* Ugly tacty to resolve sign condition for Z *)
-
 Require Import ZAux.
 Require Import Replace2.
 Require Import List.
 
 
-(* Building the tactics *)
+Definition Zsign_type := fun (x y : list Z) => Prop.
 
-Definition Zsign_type := fun (x y:list Z) => Prop.
-
-Definition Zsign_cons : forall x y, (Zsign_type  x y) := fun x y => True.
+Definition Zsign_cons : forall x y, (Zsign_type x y) := fun x y => True.
 
 Ltac Zsign_push term1 term2 := generalize (Zsign_cons term1 term2); intro.
 
 Ltac Zsign_le term :=
-  match term with 
-    (?X1 * ?X2)%Z =>  Zsign_le X1;
-                             match goal with 
-                             H1: (Zsign_type ?s1 ?s2) |- _ =>
-                                    Zsign_le X2;
-                                   match goal with 
-                                      H2: (Zsign_type ?s3 ?s4) |- _ => clear H1 H2;
-                                              let s5 := eval unfold List.app in (s1++s3) in
-                                              let s6 := eval unfold List.app in (s2++s4) in
-                                               Zsign_push s5 s6
-                                   end
-                              end
-| _ =>  let H1 := fresh "H" in
-    (((assert (H1: (0 <= term)%Z); [auto with zarith; fail | idtac])
-      ||
-     (assert (H1: (term <= 0)%Z); [auto with zarith; fail | idtac])); clear H1;
-         Zsign_push (term::nil) (@nil Z)) || Zsign_push (@nil Z) (term::nil)
-end.
+  match term with
+  | (?X1 * ?X2)%Z =>
+    Zsign_le X1;
+    match goal with
+    | H1: (Zsign_type ?s1 ?s2) |- _ =>
+      Zsign_le X2;
+      match goal with
+      | H2: (Zsign_type ?s3 ?s4) |- _ =>
+        clear H1 H2;
+        let s5 := (eval unfold List.app in (s1++s3)) in
+        let s6 := (eval unfold List.app in (s2++s4)) in
+        Zsign_push s5 s6
+      end
+    end
+  | _ =>
+    let H1 := fresh "H" in
+    ((assert (H1: (0 <= term)%Z); [auto with zarith; fail | idtac])
+     || assert (H1: (term <= 0)%Z); [auto with zarith; fail | idtac]; clear H1;
+     Zsign_push (term::nil) (@nil Z)) || Zsign_push (@nil Z) (term::nil)
+  end.
 
 Ltac Zsign_lt term :=
-  match term with 
-    (?X1 * ?X2)%Z =>  Zsign_lt X1;
-                             match goal with 
-                             H1: (Zsign_type ?s1 ?s2) |- _ =>
-                                    Zsign_lt X2;
-                                   match goal with 
-                                      H2: (Zsign_type ?s3 ?s4) |- _ => clear H1 H2;
-                                              let s5 := eval unfold List.app in (s1++s3) in
-                                              let s6 := eval unfold List.app in (s2++s4) in
-                                               Zsign_push s5 s6
-                                   end
-                              end
-| _ =>  let H1 := fresh "H" in
-    (((assert (H1: (0 < term)%Z); [auto with zarith; fail | idtac])
-      ||
-     (assert (H1: (term < 0)%Z); [auto with zarith; fail | idtac])); clear H1;
-         Zsign_push (term::nil) (@nil Z)) || Zsign_push (@nil Z) (term::nil)
-end.
-
+  match term with
+  | (?X1 * ?X2)%Z =>
+    Zsign_lt X1;
+    match goal with
+    | H1: (Zsign_type ?s1 ?s2) |- _ =>
+      Zsign_lt X2;
+      match goal with
+      | H2: (Zsign_type ?s3 ?s4) |- _ =>
+        clear H1 H2;
+        let s5 := (eval unfold List.app in (s1++s3)) in
+        let s6 := (eval unfold List.app in (s2++s4)) in
+        Zsign_push s5 s6
+      end
+    end
+  | _ =>
+    let H1 := fresh "H" in
+    ((assert (H1: (0 < term)%Z); [auto with zarith; fail | idtac])
+     || assert (H1: (term < 0)%Z); [auto with zarith; fail | idtac]; clear H1;
+     Zsign_push (term::nil) (@nil Z)) || Zsign_push (@nil Z) (term::nil)
+  end.
 
 Ltac Zsign_top0 :=
   match goal with
-  |- (0 <= ?X1)%Z => Zsign_le  X1
-| |- (?X1 <= 0)%Z => Zsign_le  X1
-| |- (0 < ?X1)%Z => Zsign_lt  X1
-| |- (?X1 < 0)%Z => Zsign_le  X1
-| |- (0 >= ?X1)%Z => Zsign_le  X1
-| |- (?X1 >= 0)%Z => Zsign_le  X1
-| |- (0 > ?X1 )%Z => Zsign_lt X1
-| |- (?X1 > 0)%Z => Zsign_le  X1
+  | |- (0 <= ?X1)%Z => Zsign_le X1
+  | |- (?X1 <= 0)%Z => Zsign_le X1
+  | |- (0 < ?X1)%Z => Zsign_lt X1
+  | |- (?X1 < 0)%Z => Zsign_le X1
+  | |- (0 >= ?X1)%Z => Zsign_le X1
+  | |- (?X1 >= 0)%Z => Zsign_le X1
+  | |- (0 > ?X1 )%Z => Zsign_lt X1
+  | |- (?X1 > 0)%Z => Zsign_le X1
   end.
-
 
 Ltac Zsign_top :=
   match goal with
-| |- (?X1 * _ <= ?X1 * _)%Z => Zsign_le  X1
-| |- (?X1 * _ < ?X1 * _)%Z => Zsign_le  X1
-| |- (?X1 * _ >= ?X1 * _)%Z => Zsign_le  X1
-| |- (?X1 * _ > ?X1 * _)%Z => Zsign_le  X1
+  | |- (?X1 * _ <= ?X1 * _)%Z => Zsign_le X1
+  | |- (?X1 * _ < ?X1 * _)%Z => Zsign_le X1
+  | |- (?X1 * _ >= ?X1 * _)%Z => Zsign_le X1
+  | |- (?X1 * _ > ?X1 * _)%Z => Zsign_le X1
   end.
-
 
 Ltac Zhyp_sign_top0 H:=
   match type of H with
-   (0 <= ?X1)%Z => Zsign_lt  X1
-|  (?X1 <= 0)%Z => Zsign_lt  X1
-|  (0 < ?X1)%Z => Zsign_lt  X1
-|  (?X1 < 0)%Z => Zsign_lt X1
-|  (0 >= ?X1)%Z => Zsign_lt  X1
-|  (?X1 >= 0)%Z => Zsign_lt  X1
-|  (0 > ?X1 )%Z => Zsign_lt X1
-|  (?X1 > 0)%Z => Zsign_lt  X1
+  | (0 <= ?X1)%Z => Zsign_lt X1
+  | (?X1 <= 0)%Z => Zsign_lt X1
+  | (0 < ?X1)%Z => Zsign_lt X1
+  | (?X1 < 0)%Z => Zsign_lt X1
+  | (0 >= ?X1)%Z => Zsign_lt X1
+  | (?X1 >= 0)%Z => Zsign_lt X1
+  | (0 > ?X1 )%Z => Zsign_lt X1
+  | (?X1 > 0)%Z => Zsign_lt X1
   end.
 
 
 Ltac Zhyp_sign_top H :=
   match type of H with
-|  (?X1 * _ <= ?X1 * _)%Z => Zsign_lt  X1
-|  (?X1 * _ < ?X1 * _)%Z => Zsign_lt X1
-|  (?X1 * _ >= ?X1 * _)%Z => Zsign_lt  X1
-|  (?X1 * _ > ?X1 * _)%Z => Zsign_lt  X1
-|  ?X1 => generalize H
+  | (?X1 * _ <= ?X1 * _)%Z => Zsign_lt X1
+  | (?X1 * _ < ?X1 * _)%Z => Zsign_lt X1
+  | (?X1 * _ >= ?X1 * _)%Z => Zsign_lt X1
+  | (?X1 * _ > ?X1 * _)%Z => Zsign_lt X1
+  | ?X1 => generalize H
   end.
 
 Ltac Zsign_get_term g :=
   match g with
-   (0 <= ?X1)%Z =>  X1
-|  (?X1 <= 0)%Z => X1
-|  (?X1 * _ <= ?X1 * _)%Z =>  X1
-|  (0 < ?X1)%Z =>  X1
-|  (?X1 < 0)%Z => X1
-|  (?X1 * _ < ?X1 * _)%Z =>  X1
-|  (0 >= ?X1)%Z => X1
-|  (?X1 >= 0)%Z => X1
-|  (?X1 * _ >= ?X1 * _)%Z =>  X1
-|  (?X1 * _  >= _)%Z => X1
-|  (0 > ?X1)%Z => X1
-|  (?X1 > 0)%Z => X1
-|  (?X1 * _ > ?X1 * _)%Z =>  X1
+  | (0 <= ?X1)%Z => X1
+  | (?X1 <= 0)%Z => X1
+  | (?X1 * _ <= ?X1 * _)%Z => X1
+  | (0 < ?X1)%Z => X1
+  | (?X1 < 0)%Z => X1
+  | (?X1 * _ < ?X1 * _)%Z => X1
+  | (0 >= ?X1)%Z => X1
+  | (?X1 >= 0)%Z => X1
+  | (?X1 * _ >= ?X1 * _)%Z => X1
+  | (?X1 * _ >= _)%Z => X1
+  | (0 > ?X1)%Z => X1
+  | (?X1 > 0)%Z => X1
+  | (?X1 * _ > ?X1 * _)%Z => X1
   end.
 
 Ltac Zsign_get_left g :=
   match g with
-|  (_ * ?X1 <=  _)%Z =>  X1
-|  (_ * ?X1 <  _)%Z =>  X1
-|  (_ * ?X1 >=  _)%Z =>  X1
-|  (_ * ?X1 >  _)%Z =>  X1
-end.
+  | (_ * ?X1 <= _)%Z => X1
+  | (_ * ?X1 < _)%Z => X1
+  | (_ * ?X1 >= _)%Z => X1
+  | (_ * ?X1 > _)%Z => X1
+  end.
 
 Ltac Zsign_get_right g :=
   match g with
-|  (_ <= _ * ?X1)%Z =>  X1
-|  (_ < _ * ?X1)%Z =>  X1
-|  (_ >= _ * ?X1)%Z =>  X1
-|  (_ > _ * ?X1)%Z =>  X1
-end.
+  | (_ <= _ * ?X1)%Z => X1
+  | (_ < _ * ?X1)%Z => X1
+  | (_ >= _ * ?X1)%Z => X1
+  | (_ > _ * ?X1)%Z => X1
+  end.
 
-Fixpoint mkZprodt (l: list Z)(t:Z) {struct l}: Z :=
-match l with nil => t | e::l1 => (e * mkZprodt l1 t)%Z end.
+Fixpoint mkZprodt (l : list Z) (t : Z) {struct l} : Z :=
+  match l with nil => t | e::l1 => (e * mkZprodt l1 t)%Z end.
 
-Fixpoint mkZprod (l: list Z) : Z :=
-match l with nil => 1%Z  | e::nil => e | e::l1 => (e * mkZprod l1)%Z end.
+Fixpoint mkZprod (l : list Z) : Z :=
+  match l with nil => 1%Z | e::nil => e | e::l1 => (e * mkZprod l1)%Z end.
 
 (* tatic for 0 ? x * y where ? is < > <= >= *)
 
-Ltac zsign_tac_aux0 := 
-match goal with
-  |- (0 <= ?X1 * ?X2)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 <= X1)%Z); auto with zarith; apply Zle_sign_pos_pos)
-      ||
-     (assert (H1: (X1 <= 0)%Z); auto with zarith; apply Zle_sign_neg_neg); try zsign_tac_aux0; clear H1)
-| |- (?X1 * ?X2 <= 0)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 <= X1)%Z); auto with zarith; apply Zle_sign_pos_neg)
-      ||
-     (assert (H1: (X1 <= 0)%Z); auto with zarith; apply Zle_sign_neg_pos); try zsign_tac_aux0; clear H1)
-| |- (0 < ?X1 * ?X2)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 < X1)%Z); auto with zarith; apply Zlt_sign_pos_pos)
-      ||
-     (assert (H1: (X1 < 0)%Z); auto with zarith; apply Zlt_sign_neg_neg); try zsign_tac_aux0; clear H1)
-| |- (?X1 * ?X2 < 0)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 < X1)%Z); auto with zarith; apply Zlt_sign_pos_neg)
-      ||
-     (assert (H1: (X1 < 0)%Z); auto with zarith; apply Zlt_sign_neg_pos); try zsign_tac_aux0; clear H1)
- | |- (?X1 * ?X2 >= 0)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 >= X1)%Z); auto with zarith; apply Zge_sign_neg_neg)
-      ||
-     (assert (H1:  (X1 >= 0)%Z); auto with zarith; apply Zge_sign_pos_pos); try zsign_tac_aux0; clear H1)
-| |- (0 >= ?X1 * ?X2)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (X1 >= 0)%Z); auto with zarith; apply Zge_sign_pos_neg)
-      ||
-     (assert (H1: (0 >= X1)%Z); auto with zarith; apply Zge_sign_neg_pos); try zsign_tac_aux0; clear H1)
-| |- (0 > ?X1 * ?X2)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 > X1)%Z); auto with zarith; apply Zgt_sign_neg_pos)
-      ||
-     (assert (H1: (X1 > 0)%Z); auto with zarith; apply Zgt_sign_pos_neg); try zsign_tac_aux0; clear H1)
-| |- (?X1 * ?X2 > 0)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 > X1)%Z); auto with zarith; apply Zgt_sign_neg_neg)
-      ||
-     (assert (H1: (X1 > 0)%Z); auto with zarith; apply Zgt_sign_pos_pos); try zsign_tac_aux0; clear H1)
-|
- _ => auto with zarith; fail 1 "zsign_tac_aux"
-end.
-
-Ltac zsign_tac0 := Zsign_top0;
+Ltac zsign_tac_aux0 :=
   match goal with
-    H1: (Zsign_type ?s1 ?s2) |- ?g => clear H1;
-    let s := eval unfold mkZprod, mkZprodt in 
-                  (mkZprodt s1 (mkZprod s2)) in
+  | |- (0 <= ?X1 * ?X2)%Z =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 <= X1)%Z); auto with zarith; apply Zle_sign_pos_pos)
+    || (assert (H1: (X1 <= 0)%Z); auto with zarith; apply Zle_sign_neg_neg);
+    try zsign_tac_aux0; clear H1
+  | |- (?X1 * ?X2 <= 0)%Z =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 <= X1)%Z); auto with zarith; apply Zle_sign_pos_neg)
+    || (assert (H1: (X1 <= 0)%Z); auto with zarith; apply Zle_sign_neg_pos);
+    try zsign_tac_aux0; clear H1
+  | |- (0 < ?X1 * ?X2)%Z =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 < X1)%Z); auto with zarith; apply Zlt_sign_pos_pos)
+    || (assert (H1: (X1 < 0)%Z); auto with zarith; apply Zlt_sign_neg_neg);
+    try zsign_tac_aux0; clear H1
+  | |- (?X1 * ?X2 < 0)%Z =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 < X1)%Z); auto with zarith; apply Zlt_sign_pos_neg)
+    || (assert (H1: (X1 < 0)%Z); auto with zarith; apply Zlt_sign_neg_pos);
+    try zsign_tac_aux0; clear H1
+  | |- (?X1 * ?X2 >= 0)%Z =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 >= X1)%Z); auto with zarith; apply Zge_sign_neg_neg)
+    || (assert (H1: (X1 >= 0)%Z); auto with zarith; apply Zge_sign_pos_pos);
+    try zsign_tac_aux0; clear H1
+  | |- (0 >= ?X1 * ?X2)%Z =>
+    let H1 := fresh "H" in
+    (assert (H1: (X1 >= 0)%Z); auto with zarith; apply Zge_sign_pos_neg)
+    || (assert (H1: (0 >= X1)%Z); auto with zarith; apply Zge_sign_neg_pos);
+    try zsign_tac_aux0; clear H1
+  | |- (0 > ?X1 * ?X2)%Z =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 > X1)%Z); auto with zarith; apply Zgt_sign_neg_pos)
+    || (assert (H1: (X1 > 0)%Z); auto with zarith; apply Zgt_sign_pos_neg);
+    try zsign_tac_aux0; clear H1
+  | |- (?X1 * ?X2 > 0)%Z =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 > X1)%Z); auto with zarith; apply Zgt_sign_neg_neg)
+    || (assert (H1: (X1 > 0)%Z); auto with zarith; apply Zgt_sign_pos_pos);
+    try zsign_tac_aux0; clear H1
+  | _ => auto with zarith; fail 1 "zsign_tac_aux"
+  end.
+
+Ltac zsign_tac0 :=
+  Zsign_top0;
+  match goal with
+  | H1: (Zsign_type ?s1 ?s2) |- ?g =>
+    clear H1;
+    let s := (eval unfold mkZprod, mkZprodt in (mkZprodt s1 (mkZprod s2))) in
     let t := Zsign_get_term g in
-         replace t with s; [try zsign_tac_aux0 | try ring]; auto with zarith
+    replace t with s; [try zsign_tac_aux0 | try ring];
+    auto with zarith
   end.
 
 (* tatic for hyp 0 ? x * y where ? is < > <= >= *)
 
-Ltac hyp_zsign_tac_aux0 H := 
-match  type of H  with
-   (0 <= ?X1 * ?X2)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 < X1)%Z); auto with zarith; generalize (Zle_sign_pos_pos_rev  _ _ H1 H)
-      ||
-     (assert (H1: (X1 < 0)%Z); auto with zarith; generalize (Zle_sign_neg_neg_rev  _ _ H1 H))); 
-     clear H; intros H; try hyp_zsign_tac_aux0 H; clear H1)
-|  (?X1 * ?X2 <= 0)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 < X1)%Z); auto with zarith; generalize (Zle_sign_pos_neg_rev  _ _ H1 H))
-      ||
-     (assert (H1: (X1 <= 0)%Z); auto with zarith; generalize (Zle_sign_neg_pos_rev  _ _ H1 H)); 
-      clear H; intros H; try hyp_zsign_tac_aux0 H; clear H1)
-|  (0 < ?X1 * ?X2)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 < X1)%Z); auto with zarith; generalize (Zlt_sign_pos_pos_rev _  _ H1 H))
-      ||
-     (assert (H1: (X1 < 0)%Z); auto with zarith; generalize (Zlt_sign_neg_neg_rev _ _ H1 H)); 
-      clear H; intros H; try hyp_zsign_tac_aux0 H; clear H1)
-|  (?X1 * ?X2 < 0)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 < X1)%Z); auto with zarith; generalize (Zlt_sign_pos_neg_rev _ _ H1 H))
-      ||
-     (assert (H1: (X1 < 0)%Z); auto with zarith; generalize (Zlt_sign_neg_pos_rev _ _ H1 H)); 
-     clear H; intros H; try hyp_zsign_tac_aux0 H; clear H1)
- |  (?X1 * ?X2 >= 0)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 >X1)%Z); auto with zarith; generalize (Zge_sign_neg_neg_rev _ _ H1 H))
-      ||
-     (assert (H1:  (X1 > 0)%Z); auto with zarith; generalize (Zge_sign_pos_pos _ _ H1 H));
-      clear H; intros H; try hyp_zsign_tac_aux0 H; clear H1)
-|  (0 >= ?X1 * ?X2)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (X1 > 0)%Z); auto with zarith; generalize (Zge_sign_pos_neg _ _ H1 H))
-      ||
-     (assert (H1: (0 > X1)%Z); auto with zarith; generalize (Zge_sign_neg_pos _ _ H1 H));
-     clear H; intros H; try hyp_zsign_tac_aux0 H; clear H1)
-|  (0 > ?X1 * ?X2)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 > X1)%Z); auto with zarith; generalize (Zgt_sign_neg_pos _ _ H1 H))
-      ||
-     (assert (H1: (X1 > 0)%Z); auto with zarith; generalize (Zgt_sign_pos_neg _ _ H1 H));
-     clear H; intros H; try hyp_zsign_tac_aux0 H; clear H1)
-|  (?X1 * ?X2 > 0)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 > X1)%Z); auto with zarith; generalize (Zgt_sign_neg_neg _ _ H1 H))
-      ||
-     (assert (H1: (X1 > 0)%Z); auto with zarith; generalize (Zgt_sign_pos_pos _ _ H1 H));
-     clear H; intros H; try hyp_zsign_tac_aux0 H; clear H1)
-|
- _ => auto with zarith; fail 1 "hyp_zsign_tac_aux0"
-end.
+Ltac hyp_zsign_tac_aux0 H :=
+  match type of H with
+  | (0 <= ?X1 * ?X2)%Z =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 < X1)%Z); auto with zarith; generalize (Zle_sign_pos_pos_rev _ _ H1 H))
+    || (assert (H1: (X1 < 0)%Z); auto with zarith; generalize (Zle_sign_neg_neg_rev _ _ H1 H));
+    clear H; intros H; try hyp_zsign_tac_aux0 H; clear H1
+  | (?X1 * ?X2 <= 0)%Z =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 < X1)%Z); auto with zarith; generalize (Zle_sign_pos_neg_rev _ _ H1 H))
+    || (assert (H1: (X1 <= 0)%Z); auto with zarith; generalize (Zle_sign_neg_pos_rev _ _ H1 H));
+    clear H; intros H; try hyp_zsign_tac_aux0 H; clear H1
+  | (0 < ?X1 * ?X2)%Z =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 < X1)%Z); auto with zarith; generalize (Zlt_sign_pos_pos_rev _ _ H1 H))
+    || (assert (H1: (X1 < 0)%Z); auto with zarith; generalize (Zlt_sign_neg_neg_rev _ _ H1 H));
+    clear H; intros H; try hyp_zsign_tac_aux0 H; clear H1
+  | (?X1 * ?X2 < 0)%Z =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 < X1)%Z); auto with zarith; generalize (Zlt_sign_pos_neg_rev _ _ H1 H))
+    || (assert (H1: (X1 < 0)%Z); auto with zarith; generalize (Zlt_sign_neg_pos_rev _ _ H1 H));
+    clear H; intros H; try hyp_zsign_tac_aux0 H; clear H1
+  | (?X1 * ?X2 >= 0)%Z =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 >X1)%Z); auto with zarith; generalize (Zge_sign_neg_neg_rev _ _ H1 H))
+    || (assert (H1: (X1 > 0)%Z); auto with zarith; generalize (Zge_sign_pos_pos _ _ H1 H));
+    clear H; intros H; try hyp_zsign_tac_aux0 H; clear H1
+  | (0 >= ?X1 * ?X2)%Z =>
+    let H1 := fresh "H" in
+    (assert (H1: (X1 > 0)%Z); auto with zarith; generalize (Zge_sign_pos_neg _ _ H1 H))
+    || (assert (H1: (0 > X1)%Z); auto with zarith; generalize (Zge_sign_neg_pos _ _ H1 H));
+    clear H; intros H; try hyp_zsign_tac_aux0 H; clear H1
+  | (0 > ?X1 * ?X2)%Z =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 > X1)%Z); auto with zarith; generalize (Zgt_sign_neg_pos _ _ H1 H))
+    || (assert (H1: (X1 > 0)%Z); auto with zarith; generalize (Zgt_sign_pos_neg _ _ H1 H));
+    clear H; intros H; try hyp_zsign_tac_aux0 H; clear H1
+  | (?X1 * ?X2 > 0)%Z =>
+    let H1 := fresh "H" in
+    (assert (H1: (0 > X1)%Z); auto with zarith; generalize (Zgt_sign_neg_neg _ _ H1 H))
+    || (assert (H1: (X1 > 0)%Z); auto with zarith; generalize (Zgt_sign_pos_pos _ _ H1 H));
+    clear H; intros H; try hyp_zsign_tac_aux0 H; clear H1
+  | _ => auto with zarith; fail 1 "hyp_zsign_tac_aux0"
+  end.
 
-Ltac hyp_zsign_tac0 H := Zhyp_sign_top0 H;
+Ltac hyp_zsign_tac0 H :=
+  Zhyp_sign_top0 H;
   match goal with
-    H1: (Zsign_type ?s1 ?s2) |- ?g => clear H1;
-    let s := eval unfold mkZprod, mkZprodt in 
-                  (mkZprodt s1 (mkZprod s2)) in
+  | H1: (Zsign_type ?s1 ?s2) |- ?g =>
+    clear H1;
+    let s := (eval unfold mkZprod, mkZprodt in (mkZprodt s1 (mkZprod s2))) in
     let t := Zsign_get_term g in
-         replace t with s in H; [try hyp_zsign_tac_aux0 H | try ring]; auto with zarith
+    replace t with s in H; [try hyp_zsign_tac_aux0 H | try ring];
+    auto with zarith
   end.
 
 (* Tactic for goal x1 * x2 ? x1 * x3 where ? is < > <= >= *)
 
-Ltac zsign_tac_aux := 
-match goal with
- | |- (?X1 * ?X2 <= ?X1 * ?X3)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 <= X1)%Z); auto with zarith; apply Zmult_le_compat_l)
-      ||
-     (assert (H1: (X1 <= 0)%Z); auto with zarith; apply Zmult_le_neg_compat_l); try zsign_tac_aux; clear H1)
-| |- (?X1 * ?X2 < ?X1 * ?X3)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 <= X1)%Z); auto with zarith; apply Zmult_lt_compat_l)
-      ||
-     (assert (H1: (X1 <= 0)%Z); auto with zarith; apply Zmult_lt_neg_compat_l); try zsign_tac_aux; clear H1) 
- | |- (?X1 * ?X2 >= ?X1 * ?X3)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (X1 >= 0)%Z); auto with zarith; apply Zmult_ge_compat_l)
-      ||
-     (assert (H1:  (0 >= X1)%Z); auto with zarith; apply Zmult_ge_neg_compat_l); try zsign_tac_aux; clear H1)
-| |- (?X1 * ?X2 > ?X1 * ?X3)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 <= X1)%Z); auto with zarith; apply Zmult_lt_compat_l)
-      ||
-     (assert (H1: (X1 <= 0)%Z); auto with zarith; apply Zmult_lt_neg_compat_l); try zsign_tac_aux; clear H1)
-|
- _ => auto with zarith; fail 1 "Zsign_tac_aux"
-end.
-
-Ltac zsign_tac := zsign_tac0 || (Zsign_top;
+Ltac zsign_tac_aux :=
   match goal with
-    H1: (Zsign_type ?s1 ?s2) |- ?g => clear H1;
-    let s := eval unfold mkZprod, mkZprodt in 
-                  (mkZprodt s1 (mkZprod s2)) in
-    let t := Zsign_get_term g in
-    let l := Zsign_get_left g in
-    let r := Zsign_get_right g in
-    let sl := eval unfold mkZprod, mkZprodt in 
-                  (mkZprodt s1 (Zmult (mkZprod s2) l)) in
-    let sr := eval unfold mkZprod, mkZprodt in 
-                  (mkZprodt s1 (Zmult (mkZprod s2) r)) in
-         replace2_tac (Zmult t l) (Zmult t r) sl sr; [zsign_tac_aux | ring | ring]
-  end).
+  | |- (?X1 * ?X2 <= ?X1 * ?X3)%Z =>
+    let H1 := fresh "H" in
+    ((assert (H1: (0 <= X1)%Z); auto with zarith; apply Zmult_le_compat_l)
+     || (assert (H1: (X1 <= 0)%Z); auto with zarith; apply Zmult_le_neg_compat_l);
+     try zsign_tac_aux; clear H1)
+  | |- (?X1 * ?X2 < ?X1 * ?X3)%Z =>
+    let H1 := fresh "H" in
+    ((assert (H1: (0 <= X1)%Z); auto with zarith; apply Zmult_lt_compat_l)
+     || (assert (H1: (X1 <= 0)%Z); auto with zarith; apply Zmult_lt_neg_compat_l);
+     try zsign_tac_aux; clear H1)
+  | |- (?X1 * ?X2 >= ?X1 * ?X3)%Z =>
+    let H1 := fresh "H" in
+    ((assert (H1: (X1 >= 0)%Z); auto with zarith; apply Zmult_ge_compat_l)
+     || (assert (H1: (0 >= X1)%Z); auto with zarith; apply Zmult_ge_neg_compat_l);
+     try zsign_tac_aux; clear H1)
+  | |- (?X1 * ?X2 > ?X1 * ?X3)%Z =>
+    let H1 := fresh "H" in
+    ((assert (H1: (0 <= X1)%Z); auto with zarith; apply Zmult_lt_compat_l)
+     || (assert (H1: (X1 <= 0)%Z); auto with zarith; apply Zmult_lt_neg_compat_l);
+     try zsign_tac_aux; clear H1)
+  | _ => auto with zarith; fail 1 "Zsign_tac_aux"
+  end.
 
+Ltac zsign_tac :=
+  zsign_tac0
+  || (Zsign_top;
+     match goal with
+     | H1: (Zsign_type ?s1 ?s2) |- ?g =>
+       clear H1;
+       let s := (eval unfold mkZprod, mkZprodt in
+                    (mkZprodt s1 (mkZprod s2)))
+       in
+       let t := Zsign_get_term g in
+       let l := Zsign_get_left g in
+       let r := Zsign_get_right g in
+       let sl := (eval unfold mkZprod, mkZprodt in
+                     (mkZprodt s1 (Zmult (mkZprod s2) l)))
+       in
+       let sr := (eval unfold mkZprod, mkZprodt in
+                     (mkZprodt s1 (Zmult (mkZprod s2) r)))
+       in
+       replace2_tac (Zmult t l) (Zmult t r) sl sr; [zsign_tac_aux | ring | ring]
+     end).
 
 (* Tactic for hyp x1 * x2 ? x1 * x3 where ? is < > <= >= *)
 
-Ltac hyp_zsign_tac_aux H := 
-match type of H with
- | (?X1 * ?X2 <= ?X1 * ?X3)%Z =>
-  let H1 := fresh "H" in
+Ltac hyp_zsign_tac_aux H :=
+  match type of H with
+  | (?X1 * ?X2 <= ?X1 * ?X3)%Z =>
+    let H1 := fresh "H" in
     ((assert (H1: (0 < X1)%Z); auto with zarith; generalize (Zmult_le_compat_l_rev _ _ _ H1 H))
-      ||
-     (assert (H1: (X1 < 0)%Z); auto with zarith; generalize (Zmult_le_neg_compat_l_rev _ _ _ H1 H)); 
+     || (assert (H1: (X1 < 0)%Z); auto with zarith; generalize (Zmult_le_neg_compat_l_rev _ _ _ H1 H));
      clear H; intros H; try hyp_zsign_tac_aux H; clear H1)
-|  (?X1 * ?X2 < ?X1 * ?X3)%Z =>
-  let H1 := fresh "H" in
+  | (?X1 * ?X2 < ?X1 * ?X3)%Z =>
+    let H1 := fresh "H" in
     ((assert (H1: (0 < X1)%Z); auto with zarith; generalize (Zmult_lt_compat_l_rev _ _ _ H1 H))
-      ||
-     (assert (H1: (X1 < 0)%Z); auto with zarith; generalize (Zmult_lt_neg_compat_l_rev _ _ _ H1 H)); 
-    clear H; intros H; try hyp_zsign_tac_aux H; clear H1) 
- |  (?X1 * ?X2 >= ?X1 * ?X3)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (X1 > 0)%Z); auto with zarith; generalize (Zmult_ge_compat_l_rev _ _ _ H1 H))
-      ||
-     (assert (H1:  (0 > X1)%Z); auto with zarith; generalize (Zmult_ge_neg_compat_l_rev _ _ _ H1 H)); 
-    clear H; intros H; try hyp_zsign_tac_aux H; clear H1)
-| (?X1 * ?X2 > ?X1 * ?X3)%Z =>
-  let H1 := fresh "H" in
-    ((assert (H1: (0 < X1)%Z); auto with zarith; generalize (Zmult_gt_compat_l_rev _ _ _ H1 H))
-      ||
-     (assert (H1: (X1 < 0)%Z); auto with zarith; generalize (Zmult_gt_neg_compat_l_rev _ _ _ H1 H)); 
+     || (assert (H1: (X1 < 0)%Z); auto with zarith; generalize (Zmult_lt_neg_compat_l_rev _ _ _ H1 H));
      clear H; intros H; try hyp_zsign_tac_aux H; clear H1)
-|
- _ => auto with zarith; fail 0 "Zhyp_sign_tac_aux"
-end.
+  | (?X1 * ?X2 >= ?X1 * ?X3)%Z =>
+    let H1 := fresh "H" in
+    ((assert (H1: (X1 > 0)%Z); auto with zarith; generalize (Zmult_ge_compat_l_rev _ _ _ H1 H))
+     || (assert (H1: (0 > X1)%Z); auto with zarith; generalize (Zmult_ge_neg_compat_l_rev _ _ _ H1 H));
+     clear H; intros H; try hyp_zsign_tac_aux H; clear H1)
+  | (?X1 * ?X2 > ?X1 * ?X3)%Z =>
+    let H1 := fresh "H" in
+    ((assert (H1: (0 < X1)%Z); auto with zarith; generalize (Zmult_gt_compat_l_rev _ _ _ H1 H))
+     || (assert (H1: (X1 < 0)%Z); auto with zarith; generalize (Zmult_gt_neg_compat_l_rev _ _ _ H1 H));
+     clear H; intros H; try hyp_zsign_tac_aux H; clear H1)
+  | _ => auto with zarith; fail 0 "Zhyp_sign_tac_aux"
+  end.
 
-Ltac hyp_zsign_tac H := hyp_zsign_tac0  H||( Zhyp_sign_top H;
-  match goal with
-    H1: (Zsign_type ?s1 ?s2) |- _ => clear H1;
-    let s := eval unfold mkZprod, mkZprodt in 
-                  (mkZprodt s1 (mkZprod s2)) in
-    let g := type of H in
-    let t := Zsign_get_term g in
-    let l := Zsign_get_left g in
-    let r := Zsign_get_right g in
-    let sl := eval unfold mkZprod, mkZprodt in 
-                  (mkZprodt s1 (Zmult (mkZprod s2) l)) in
-    let sr := eval unfold mkZprod, mkZprodt in 
-                  (mkZprodt s1 (Zmult (mkZprod s2) r)) in
-         (generalize H; replace2_tac (Zmult t l) (Zmult t r) sl sr; [clear H; intros H; try hyp_zsign_tac_aux H| ring | ring])
-  end).
+Ltac hyp_zsign_tac H :=
+  hyp_zsign_tac0 H
+  || (Zhyp_sign_top H;
+     match goal with
+     | H1: (Zsign_type ?s1 ?s2) |- _ =>
+       clear H1;
+       let s := (eval unfold mkZprod, mkZprodt in
+                    (mkZprodt s1 (mkZprod s2)))
+       in
+       let g := type of H in
+       let t := Zsign_get_term g in
+       let l := Zsign_get_left g in
+       let r := Zsign_get_right g in
+       let sl := (eval unfold mkZprod, mkZprodt in
+                     (mkZprodt s1 (Zmult (mkZprod s2) l)))
+       in
+       let sr := (eval unfold mkZprod, mkZprodt in
+                     (mkZprodt s1 (Zmult (mkZprod s2) r)))
+       in
+       generalize H; replace2_tac (Zmult t l) (Zmult t r) sl sr;
+       [clear H; intros H; try hyp_zsign_tac_aux H | ring | ring]
+     end).
 
 Section Test.
 
-Let test : forall a b c, (0 < a -> a * b < a * c -> b < c)%Z.
-intros a b c H H1.
-hyp_zsign_tac H1.
+Let test1 : forall a b c, (0 < a -> a * b < a * c -> b < c)%Z.
+Proof.
+intros a b c H1 H2.
+hyp_zsign_tac H2.
 Qed.
 
 
-Let test1 : forall a b c, (a < 0 -> a * b < a * c -> c < b)%Z.
-intros a b c H H1.
-hyp_zsign_tac H1.
+Let test2 : forall a b c, (a < 0 -> a * b < a * c -> c < b)%Z.
+Proof.
+intros a b c H1 H2.
+hyp_zsign_tac H2.
 Qed.
 
-Let test2 : forall a b c, (0 < a -> a * b <= a * c -> b <= c)%Z.
-intros a b c H H1.
-hyp_zsign_tac H1.
+Let test3 : forall a b c, (0 < a -> a * b <= a * c -> b <= c)%Z.
+Proof.
+intros a b c H1 H2.
+hyp_zsign_tac H2.
 Qed.
 
-Let test3 : forall a b c, (a < - 0 -> a * b >= a * c -> c >= b)%Z.
-intros a b c H H1.
-hyp_zsign_tac H1.
+Let test4 : forall a b c, (a < - 0 -> a * b >= a * c -> c >= b)%Z.
+Proof.
+intros a b c H1 H2.
+hyp_zsign_tac H2.
 Qed.
 
 End Test.

--- a/Zex.v
+++ b/Zex.v
@@ -3,51 +3,67 @@ Require Import PolTac.
 
 Open Scope Z_scope.
 
-Theorem pols_test1: forall (x y : Z), x < y ->  (x + x < y + x).
+Theorem pols_test1 x y :
+  x < y -> x + x < y + x.
+Proof.
 intros.
 pols.
 auto.
 Qed.
- 
-Theorem pols_test2: forall (x y : Z), y < 0 ->  (x + y < x).
+
+Theorem pols_test2 x y :
+  y < 0 -> x + y < x.
+Proof.
 intros.
 pols.
 auto.
 Qed.
- 
-Theorem pols_test3: forall (x y : Z), 0 < y * y ->  ((x + y) * (x - y) < x * x).
+
+Theorem pols_test3 x y :
+  0 < y * y ->
+  (x + y) * (x - y) < x * x.
+Proof.
 intros.
 pols.
 auto with zarith.
 Qed.
- 
-Theorem pols_test4:
- forall (x y : Z),
- x * x  < y * y ->  ((x + y) * (x + y) < 2 * (x * y + y * y)).
-intros.
-pols.
-auto.
-Qed.
- 
-Theorem pols_test5:
- forall x y z, x + y * (y + z) = 2 * z ->  2 * x + y * (y + z) = (x + z) + z.
+
+Theorem pols_test4 x y :
+  x * x < y * y ->
+  (x + y) * (x + y) < 2 * (x * y + y * y).
+Proof.
 intros.
 pols.
 auto.
 Qed.
 
-Theorem polf_test1: forall x y, (0 <= x -> 1 <= y -> x  <= x  * y)%Z.
+Theorem pols_test5 x y z :
+  x + y * (y + z) = 2 * z ->
+  2 * x + y * (y + z) = (x + z) + z.
+Proof.
+intros.
+pols.
+auto.
+Qed.
+
+Theorem polf_test1 x y :
+  0 <= x -> 1 <= y -> x <= x * y.
+Proof.
 intros.
 polf.
 Qed.
 
-Theorem polf_test2: forall x y, (0 < x -> x  <= x  * y -> 1 <= y)%Z.
-intros.
-hyp_polf H0.
+Theorem polf_test2 x y :
+  0 < x -> x <= x * y -> 1 <= y.
+Proof.
+intros H1 H2.
+hyp_polf H2.
 Qed.
 
-Theorem polr_test1: forall x y z, (x + z) < y -> x + y + z < 2*y.
-intros x y z H.
+Theorem polr_test1 x y z :
+  x + z < y -> x + y + z < 2 * y.
+Proof.
+intros H.
 polr H.
 pols.
 auto.


### PR DESCRIPTION
- Use Proof General to indent the codebase(now stable under automatic indentation)
- add `Proof.` to theorems
- remove accidental whitespace
- remove redundant parentheses